### PR TITLE
Save generated artifacts programmatically instead of filesystem MCP

### DIFF
--- a/eval/instructions.py
+++ b/eval/instructions.py
@@ -151,8 +151,8 @@ Always use openai/gpt-4.1 as the llm_judge.
 """  # noqa: E501
 
 INSTRUCTIONS_TEMPLATE = """
-1. List files in the generated_workflows directory.
-2. Check the file generated_workflows/agent.py.
+1. List files in the generated_workflows/latest directory.
+2. Check the file generated_workflows/latest/agent.py.
 3. Generate a comprehensive JSON evaluation file for the given agent.py script.
 
 Analyze the agent's task, tools, and expected workflow to create thorough evaluation criteria.

--- a/eval/main.py
+++ b/eval/main.py
@@ -60,7 +60,7 @@ def parse_checkpoint_criteria_string(input_string: str) -> dict:
     return result_dict
 
 
-def main(generated_workflow_dir: str = "generated_workflows"):
+def main(generated_workflow_dir: str = "generated_workflows/latest"):
     """Generate JSON structured evaluation case for the generated agentic workflow.
     Save the JSON file as `evaluation_case.yaml` in the same directory as the generated workflow.
 
@@ -125,7 +125,7 @@ def main(generated_workflow_dir: str = "generated_workflows"):
     )
 
     run_instructions = """
-    Read the generated_workflows/agent.py script and generate a JSON evaluation case for it.
+    Read the generated_workflows/latest/agent.py script and generate a JSON evaluation case for it.
     The criteria generated must:
     - be specific, measurable, and independent.
     - should not be vague or open-ended or generic.

--- a/eval/run_agent_eval.py
+++ b/eval/run_agent_eval.py
@@ -7,8 +7,8 @@ from any_agent.tracing.agent_trace import AgentTrace
 
 
 def run_evaluation(
-    evaluation_case_yaml_file: str = "generated_workflows/evaluation_case.yaml",
-    agent_trace_json_file: str = "generated_workflows/agent_trace.json",
+    evaluation_case_yaml_file: str = "generated_workflows/latest/evaluation_case.yaml",
+    agent_trace_json_file: str = "generated_workflows/latest/agent_eval_trace.json",
 ):
     """Runs the evaluation process based on an evaluation case YAML file and an agent trace JSON file.
 
@@ -16,7 +16,7 @@ def run_evaluation(
         evaluation_case_yaml_file (str): Path to the evaluation case YAML file.
                                          Defaults to "generated_workflows/evaluation_case.yaml".
         agent_trace_json_file (str): Path to the agent trace JSON file.
-                                     Defaults to "generated_workflows/agent_trace.json".
+                                     Defaults to "generated_workflows/agent_eval_trace.json".
     """
     try:
         # Load evaluation case from the specified YAML file

--- a/src/instructions.py
+++ b/src/instructions.py
@@ -110,31 +110,29 @@ agent = AnyAgent.create(
 user_input = "Example user input"
 agent.run(prompt=f"Example prompt referencing the task and the input: {user_input}")
 
-# Saving the agent trace at the end
-with open("generated_workflows/agent_trace.json", "w", encoding="utf-8") as f:
+# Saving the agent trace at the end as agent_eval_trace.json in the generated_workflows/latest directory
+with open("generated_workflows/latest/agent_eval_trace.json", "w", encoding="utf-8") as f:
     f.write(agent_trace.model_dump_json(indent=2))
 """
 
-SAVE_FILE_INSTRUCTIONS = """
-The generated code and associated files should be saved in the `generated_workflows/` directory. The three files to be saved are:
+DELIVERABLES_INSTRUCTIONS = """
+The final output should be a JSON with the following structure:
 
-1. Complete `agent.py` file with all the code implementation of the agent
-2. INSTRUCTIONS.md with clear and concise setup:
+{
+    "agent_code": "The agent script in Markdown format",
+    "run_instructions": "The instructions for setting up the environment in Markdown format",
+    "dependencies": "The list of python dependencies in Markdown format"
+}
+
+1. agent_code should contain all the code implementation of the agent which will correspond to the runnable agent.py script
+2. run_instructions should contain clear and concise setup instructions:
     - Environment variables: Instruct the user to create a .env file to set environment variables; specify exactly which environment variables are required
     - Setting up the environment via mamba (Python version 3.11)
     - Installing dependencies via requirements.txt
     - Run instructions for agent.py
-3. A requirements.txt file listing all the python libraries (including the ones required by the tools) as dependencies to be installed.
-
-Use the `write_file` tool to save the generated artifacts, name the files `agent.py`, `INSTRUCTIONS.md` and `requirements.txt`.
-
-- In the requirements.txt file,
-    - the first line should be "any-agent[all]" dependency, since we are using any-agent to run the agent workflow.
-    - the second line should be "uv" dependency, if we use uvx to spin up any MCP server that will be used in the code.
-
-- All 3 files should be saved to the /app/generated_workflows directory as /app/generated_workflows/agent.py, /app/generated_workflows/INSTRUCTIONS.md and /app/generated_workflows/requirements.txt.
-- You must save the 3 files (no need to ask for permission)
-- Check if they exist in the /app/generated_workflows directory before stopping.
+3. dependencies should list all the python libraries (including the ones required by the tools) as dependencies to be installed. It will be used to generate the requirements.txt file
+    - the first line should be "any-agent[all]" dependency, since we are using any-agent to run the agent workflow
+    - the second line should be "uv" dependency, if we use uvx to spin up any MCP server that will be used in the code
 
 """  # noqa: E501
 
@@ -188,9 +186,12 @@ Refer to the any-agent documentation for valid parameters for AgentConfig.
 - Refer to the any-agent documentation for more details on structured output
 
 #### Agent Trace (agent_trace):
-The code implementation should include the agent trace being saved into a JSON file named `agent_trace.json` after agent.run().
-- Saving of the agent trace in the code should be done to the `generated_workflows/` directory
-- You would accomplish this by including the lines agent_trace.model_dump_json(indent=2) as shown in the example code.
+The code implementation should include the agent trace being saved into a JSON file named `agent_eval_trace.json` immediately after agent.run()
+- Saving of the agent trace in the code should be done to the `generated_workflows/latest/` directory. You may assume that the `generated_workflows/latest/` directory already exists
+- You would accomplish this by including the lines agent_trace.model_dump_json(indent=2) as shown in the example code
+- Never try to print, log or access any other properties of the agent trace object. agent_trace.response or agent_trace.output are invalid
+- Only agent_trace.model_dump_json(indent=2) and agent_trace.final_output are valid
+- Do not print or save anything after saving the agent trace
 
 ### Code Organization
 - Create well-documented, modular code with appropriate comments
@@ -229,8 +230,8 @@ For reading URLs, use `visit_webpage` tool (never use the `read_file` tool for r
 As input to the AgentConfig, you are required to provide the parameters `model_id`, `instructions`, `tools`, and `agent_args`:
 {{ code_example_with_comments }}
 
-** Save File Instructions**
-{{ save_file_instructions }}
+** Deliverables Instructions**
+{{ deliverables_instructions }}
 """  # noqa: E501
 
 # Render the template with the WEBPAGE_DESCRIPTIONS dictionary
@@ -239,5 +240,5 @@ INSTRUCTIONS = template.render(
     webpage_descriptions=WEBPAGE_DESCRIPTIONS,
     code_generation_instructions=CODE_GENERATION_INSTRUCTIONS,
     code_example_with_comments=CODE_EXAMPLE_WITH_COMMENTS,
-    save_file_instructions=SAVE_FILE_INSTRUCTIONS,
+    deliverables_instructions=DELIVERABLES_INSTRUCTIONS,
 )

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import uuid
@@ -9,6 +10,7 @@ import fire
 from any_agent import AgentConfig, AgentFramework, AnyAgent
 from any_agent.config import MCPStdio
 from any_agent.tools import visit_webpage
+from pydantic import BaseModel, Field
 from src.instructions import INSTRUCTIONS
 
 dotenv.load_dotenv()
@@ -19,125 +21,182 @@ tools_dir = repo_root / "tools"
 mcps_dir = repo_root / "mcps"
 
 
-def main(user_prompt: str, workflow_dir: Path | None = None):
-    """Generate python code for an agentic workflow based on the user prompt.
+class AgentFactoryOutputs(BaseModel):
+    agent_code: str = Field(..., description="The agent code in Markdown format")
+    run_instructions: str = Field(..., description="The run instructions in Markdown format")
+    dependencies: str = Field(..., description="The dependencies line by line in Markdown format")
 
-    Args:
-        user_prompt: The user's prompt describing what the agentic workflow should do.
-        workflow_dir: Optional. Path to the workflow directory. If not provided, a new one is created.
 
-    Returns:
-        The final output from the agent.
-    """
-    workflow_id = str(uuid.uuid4())
-    # Create a unique workflow directory if not provided
-    if workflow_dir is None:
-        workflow_dir = workflows_root / "latest"
-    else:
-        workflow_dir = Path(workflow_dir)
+def get_mount_config():
+    return {
+        "host_tools_dir": str(tools_dir),
+        "host_mcps_dir": str(mcps_dir),
+        "container_tools_dir": "/app/tools",
+        "container_mcps_dir": "/app/mcps",
+        "file_ops_dir": "/app",
+    }
 
-    # Create generated_workflows directory if it doesn't exist
+
+def get_default_tools(mount_config):
+    return [
+        visit_webpage,
+        MCPStdio(
+            command="docker",
+            args=[
+                "run",
+                "-i",
+                "--rm",
+                "-e",
+                "BRAVE_API_KEY",
+                "mcp/brave-search",
+            ],
+            env={
+                "BRAVE_API_KEY": os.getenv("BRAVE_API_KEY"),
+            },
+            tools=[
+                "brave_web_search",
+            ],
+        ),
+        MCPStdio(
+            command="docker",
+            args=[
+                "run",
+                "-i",
+                "--rm",
+                "--volume",
+                "/app",
+                # Mount tools directory
+                "--mount",
+                f"type=bind,src={mount_config['host_tools_dir']},dst={mount_config['container_tools_dir']}",
+                # Mount mcps directory
+                "--mount",
+                f"type=bind,src={mount_config['host_mcps_dir']},dst={mount_config['container_mcps_dir']}",
+                "mcp/filesystem",
+                mount_config["file_ops_dir"],
+            ],
+            tools=[
+                "read_file",
+                "list_directory",
+            ],
+        ),
+    ]
+
+
+def validate_agent_outputs(str_output: str):
+    try:
+        json_output = json.loads(str_output)
+        agent_factory_outputs = AgentFactoryOutputs.model_validate(json_output)
+    except Exception as e:
+        raise ValueError(
+            f"Invalid format received for agent outputs: {e}. Could not parse the output as AgentFactoryOutputs."
+        ) from e
+    return agent_factory_outputs
+
+
+def remove_markdown_code_block_delimiters(text: str) -> str:
+    """Remove backticks from the start and end of markdown output."""
+    text = text.strip()
+    if text.startswith("```") and text.endswith("```"):
+        lines = text.splitlines()
+        return "\n".join(lines[1:-1])
+    return text
+
+
+def save_agent_outputs(output: AgentFactoryOutputs, generated_workflows_dir: str = "latest"):
+    """Save all three outputs from AgentFactoryOutputs to separate files."""
+    save_artifacts_dir = workflows_root / generated_workflows_dir
+    Path(save_artifacts_dir).mkdir(exist_ok=True)
+
+    agent_path = Path(f"{save_artifacts_dir}/agent.py")
+    instructions_path = Path(f"{save_artifacts_dir}/INSTRUCTIONS.md")
+    requirements_path = Path(f"{save_artifacts_dir}/requirements.txt")
+
+    with agent_path.open("w", encoding="utf-8") as f:
+        f.write(remove_markdown_code_block_delimiters(output.agent_code))
+
+    with instructions_path.open("w", encoding="utf-8") as f:
+        f.write(output.run_instructions)
+
+    with requirements_path.open("w", encoding="utf-8") as f:
+        f.write(remove_markdown_code_block_delimiters(output.dependencies))
+
+    print(f"Files saved to {save_artifacts_dir}")
+
+
+def setup_directories(workflows_root, workflow_dir):
     workflows_root.mkdir(parents=True, exist_ok=True)
     workflow_dir.mkdir(parents=True, exist_ok=True)
+    latest_dir = workflows_root / "latest"
+    archive_root = workflows_root / "archive"
+    latest_dir.mkdir(parents=True, exist_ok=True)
+    archive_root.mkdir(parents=True, exist_ok=True)
+    return latest_dir, archive_root
 
-    # Create a separate directory for file operations
-    file_ops_dir = "/app"
-    mount_workflows_dir = "/app/generated_workflows"
-    mount_tools_dir = "/app/tools"
-    mount_mcps_dir = "/app/mcps"
 
+def create_agent(mount_config):
     framework = AgentFramework.OPENAI
     agent = AnyAgent.create(
         framework,
         AgentConfig(
             model_id="gpt-4.1",
             instructions=INSTRUCTIONS,
-            tools=[
-                visit_webpage,
-                MCPStdio(
-                    command="docker",
-                    args=[
-                        "run",
-                        "-i",
-                        "--rm",
-                        "-e",
-                        "BRAVE_API_KEY",
-                        "mcp/brave-search",
-                    ],
-                    env={
-                        "BRAVE_API_KEY": os.getenv("BRAVE_API_KEY"),
-                    },
-                    tools=[
-                        "brave_web_search",
-                    ],
-                ),
-                MCPStdio(
-                    command="docker",
-                    args=[
-                        "run",
-                        "-i",
-                        "--rm",
-                        "--volume",
-                        "/app",
-                        # Mount workflows directory
-                        "--mount",
-                        f"type=bind,src={workflows_root},dst={mount_workflows_dir}",
-                        # Mount tools directory
-                        "--mount",
-                        f"type=bind,src={tools_dir},dst={mount_tools_dir}",
-                        # Mount mcps directory
-                        "--mount",
-                        f"type=bind,src={mcps_dir},dst={mount_mcps_dir}",
-                        "mcp/filesystem",
-                        file_ops_dir,
-                    ],
-                    tools=[
-                        "read_file",
-                        "write_file",
-                        "list_directory",
-                    ],
-                ),
-            ],
+            tools=get_default_tools(mount_config),
         ),
     )
+    return agent
 
-    # Always use 'latest' for the agent's output
-    latest_dir = workflows_root / "latest"
-    archive_root = workflows_root / "archive"
-    timestamp_id = datetime.now().strftime("%Y-%m-%d_%H:%M:%S") + "_" + workflow_id[:8]
-    archive_dir = archive_root / timestamp_id
 
-    # Ensure directories exist
-    latest_dir.mkdir(parents=True, exist_ok=True)
-    archive_dir.mkdir(parents=True, exist_ok=True)
+def build_run_instructions(user_prompt):
+    return f"""
+    ## Tools
+    You may use appropriate tools provided from tools/available_tools.md in the agent configuration.
+    In addition to the tools pre-defined in available_tools.md,
+    two other tools that you could use are search_web and visit_webpage.
 
-    # For the agent, always use 'latest'
-    container_workflow_dir = "/app/generated_workflows/latest"
+    ## MCPs
+    You may use appropriate MCPs provided from mcps/available_mcps.md in the agent configuration.
 
-    run_instructions = f"""
     Generate python code for an agentic workflow using any-agent library to be able to do the following:
     {user_prompt}
-
-    ## File Saving Instructions
-    YOU MUST save all generated files (including agent.py, INSTRUCTIONS.md, requirements.txt, etc.)
-    inside the directory: `{container_workflow_dir}`. For example, save agent.py as `{container_workflow_dir}/agent.py`
-    and overwrite the files if they already exist. Double check that the saved files exist using list_directory tool
-    and that the latest version have been saved or overwritten correctly before stopping.
     """
 
-    agent_trace = agent.run(run_instructions, max_turns=30)
 
-    # Save agent trace in both locations
-    agent_trace_path_latest = latest_dir / "agent_trace.json"
+def save_agent_trace(agent_trace, latest_dir):
+    agent_trace_path_latest = latest_dir / "agent_factory_trace.json"
     with Path.open(agent_trace_path_latest, "w", encoding="utf-8") as f:
         f.write(agent_trace.model_dump_json(indent=2))
 
-    # Copy everything from latest to archive
+
+def archive_latest_run_artifacts(latest_dir, archive_dir):
     for item in latest_dir.iterdir():
         shutil.copy(item, archive_dir / item.name)
 
+
+def main(user_prompt: str, workflow_dir: Path | None = None):
+    """Generate python code for an agentic workflow based on the user prompt."""
+    workflow_id = str(uuid.uuid4())
+    if workflow_dir is None:
+        workflow_dir = workflows_root / "latest"
+    else:
+        workflow_dir = Path(workflow_dir)
+
+    latest_dir, archive_root = setup_directories(workflows_root, workflow_dir)
+    timestamp_id = datetime.now().strftime("%Y-%m-%d_%H:%M:%S") + "_" + workflow_id[:8]
+    archive_dir = archive_root / timestamp_id
+    archive_dir.mkdir(parents=True, exist_ok=True)
+
+    mount_config = get_mount_config()
+    agent = create_agent(mount_config)
+    run_instructions = build_run_instructions(user_prompt)
+
+    agent_trace = agent.run(run_instructions, max_turns=30)
+    agent_factory_outputs = validate_agent_outputs(agent_trace.final_output)
+    save_agent_outputs(agent_factory_outputs, latest_dir)
+    save_agent_trace(agent_trace, latest_dir)
+    archive_latest_run_artifacts(latest_dir, archive_dir)
+
     print(f"Workflow files saved in: {latest_dir} and archived in {archive_dir}")
-    print(agent_trace.final_output)
+    print(agent_factory_outputs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Main changes:
* Updated `src/instructions.py` SAVE_FILE_INSTRUCTIONS -> DELIVERABLES_INSTRUCTIONS
* Refactor `main()` in `src/main.py` into smaller functions
* Use `AgentFactoryOutputs` -> code and instruction artifacts returned as JSON which are validated against this pydantic schema and then saved programmatically; error raised if JSON parsing fails (better than silent failure of agent not using filesystem MCP to write files)

Other changes:
* Updates eval code save paths as a follow up to https://github.com/mozilla-ai/agent-factory/pull/26

To test:
* Follow the 4 step instructions on https://github.com/mozilla-ai/agent-factory?tab=readme-ov-file#1-generate-the-workflow
