### PR TITLE
fix: remove excludes from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,6 @@ version = "0.1.0"
 description = "Agentic Workflow Builder"
 readme = "README.md"
 requires-python = ">=3.11"
-exclude = [
-  "api/.*",
-  "ui/.*",
-]
 dependencies = [
     "any-agent[all]>=0.17.0",
     "jinja2>=3.1.2",


### PR DESCRIPTION
Fixes pip install issues due to wrong "exclude" syntax in pyproject.toml

Closes http://github.com/mozilla-ai/agent-factory/issues/41