### PR TITLE
feat: replace brave search with tavily

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ Before running the agent factory, you need to set up your OpenAI API key (requir
 > ```bash
 > export OPENAI_API_KEY=sk-...
 > ```
-You will need a Brave Search API key to use the `brave_web-search` tool. Create an account at [Brave Search](https://brave.com/search/api/) and obtain your API key.
+
+You will need a Tavily API key to use the `tavily_search` tool. You can get a free API key by signing up at [Tavily](https://app.tavily.com/). 
 > Set it as an environment variable:
 > ```bash
-> export BRAVE_API_KEY=BS...
+> export TAVILY_API_KEY=tvly_...
 > ```
+
 
 
 ### 1. Generate the workflow

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ You will need a Tavily API key to use the `tavily_search` tool. You can get a fr
 > export TAVILY_API_KEY=tvly_...
 > ```
 
-
+> [!TIP]
+> If you do not want to create an API key for web search, you can specify in your workflow definition that you want to use DuckDuckGo as the search tool (e.g., "use DuckDuckGo for web search"). This does not require an API key. However, please note that for complex workflows, you may hit the cap of searches per minute with DuckDuckGo.
 
 ### 1. Generate the workflow
 Run the code generator agent with your desired workflow prompt:

--- a/eval/instructions.py
+++ b/eval/instructions.py
@@ -40,7 +40,7 @@ AGENT_SCRIPT_AND_JSON_EXAMPLE = """
 ```python
 # Example imports for the agent.py file:
 from any_agent import AnyAgent, AgentConfig, AgentFramework, TracingConfig
-from any_agent.tools import search_web, visit_webpage
+from any_agent.tools import search_tavily, visit_webpage
 from any_agent.config import MCPStdio
 from tools.review_code_with_llm import review_code_with_llm
 from pydantic import BaseModel, Field
@@ -64,7 +64,7 @@ agent = AnyAgent.create(
         model_id="gpt-4.1",
         instructions="Example instructions",
         tools=[
-            search_web, # Example tool available from any-agent library
+            search_tavily, # Example tool available from any-agent library
             review_code_with_llm, # Example tool taken from tools/available_tools.md
             # Example of MCP server usage
             MCPStdio(
@@ -108,7 +108,7 @@ agent.run(prompt=user_input)
   "checkpoints": [
     {
       "points": 2,
-      "criteria": "Ensure that the agent called search_web or brave_web_search to find relevant information about code review best practices or specific technologies mentioned in the code"
+      "criteria": "Ensure that the agent called search_tavily or brave_web_search to find relevant information about code review best practices or specific technologies mentioned in the code"
     },
     {
       "points": 2,

--- a/eval/main.py
+++ b/eval/main.py
@@ -8,7 +8,7 @@ import fire
 import yaml
 from any_agent import AgentConfig, AgentFramework, AnyAgent
 from any_agent.config import MCPStdio
-from any_agent.tools import visit_webpage
+from any_agent.tools import visit_webpage, search_tavily
 from eval.instructions import INSTRUCTIONS
 from pydantic import BaseModel, Field, ValidationError
 
@@ -83,23 +83,7 @@ def main(generated_workflow_dir: str = "generated_workflows/latest"):
             instructions=INSTRUCTIONS,
             tools=[
                 visit_webpage,
-                MCPStdio(
-                    command="docker",
-                    args=[
-                        "run",
-                        "-i",
-                        "--rm",
-                        "-e",
-                        "BRAVE_API_KEY",
-                        "mcp/brave-search",
-                    ],
-                    env={
-                        "BRAVE_API_KEY": os.getenv("BRAVE_API_KEY"),
-                    },
-                    tools=[
-                        "brave_web_search",
-                    ],
-                ),
+                search_tavily,
                 MCPStdio(
                     command="docker",
                     args=[

--- a/mcps/available_mcps.md
+++ b/mcps/available_mcps.md
@@ -3,32 +3,32 @@
 Below is the list of all available MCP servers, a description of each MCP, a link to its README and the configuration of how it must be used in the agent configuration.
 For each MCP server, you can also check available MCP tools from the provided link (either Python file or JavaScript/TypeScript file).
 
-1. Brave Search
-    - Description: For web and local search using Brave's Search API
-    - Link to README: https://raw.githubusercontent.com/modelcontextprotocol/servers-archived/main/src/brave-search/README.md
-    - Check available MCP tools: https://raw.githubusercontent.com/modelcontextprotocol/servers-archived/main/src/brave-search/index.ts
+
+
+1. Obsidian
+    - Description: For interacting with Obsidian vaults, reading and writing notes, etc.
+    - Link to README: https://raw.githubusercontent.com/smithery-ai/mcp-obsidian/main/README.md
+    - Check available MCP tools: https://raw.githubusercontent.com/smithery-ai/mcp-obsidian/main/index.ts
     - Configuration:
     ```
     {
-    "mcpServers": {
-        "brave-search": {
-        "command": "docker",
-        "args": [
-            "run",
-            "-i",
-            "--rm",
-            "-e",
-            "BRAVE_API_KEY",
-            "mcp/brave-search"
-        ],
-        "env": {
-            "BRAVE_API_KEY": "YOUR_API_KEY_HERE"
+        "mcpServers": {
+            "mcp-obsidian": {
+                "command": "npx",
+                "args": [
+                    "-y",
+                    "@smithery/cli@latest",
+                    "run",
+                    "mcp-obsidian",
+                    "--config",
+                    "\"{\\\"vaultPath\\\":\\\"/absolute/path/to/your/vault\\\"}\""
+                ]
+            }
         }
-        }
-    }
     }
     ```
-    Note: You may only use `brave_web_search` tool from this MCP server and never use `brave_local_search` tool.
+    Note: Set the `vaultPath` in the configuration to the absolute path of your Obsidian vault. No environment variables are required. Ensure the agent has read/write permissions to the specified vault directory. The configuration must use a valid absolute path for the vault, and the path should be accessible from the environment where the agent is running.
+
 
 2. ElevenLabs Text-to-Speech
     - Description: For text-to-speech and audio processing using ElevenLabs API
@@ -105,7 +105,7 @@ For each MCP server, you can also check available MCP tools from the provided li
     }
     }
     ```
-
+    
 5. GitHub
     - Description: For extracting and analysing data from GitHub repositories and automating GitHub workflows and processes.
     - Link to README: https://raw.githubusercontent.com/modelcontextprotocol/servers-archived/main/src/github/README.md

--- a/mcps/available_mcps.md
+++ b/mcps/available_mcps.md
@@ -3,32 +3,24 @@
 Below is the list of all available MCP servers, a description of each MCP, a link to its README and the configuration of how it must be used in the agent configuration.
 For each MCP server, you can also check available MCP tools from the provided link (either Python file or JavaScript/TypeScript file).
 
-
-
-1. Obsidian
-    - Description: For interacting with Obsidian vaults, reading and writing notes, etc.
-    - Link to README: https://raw.githubusercontent.com/smithery-ai/mcp-obsidian/main/README.md
-    - Check available MCP tools: https://raw.githubusercontent.com/smithery-ai/mcp-obsidian/main/index.ts
+1. DuckDuckGo Search
+    - Description: For web search using DuckDuckGo's Search API
+    - Link to README: https://raw.githubusercontent.com/nickclyde/duckduckgo-mcp-server/main/README.md
+    - Check available MCP tools: https://raw.githubusercontent.com/nickclyde/duckduckgo-mcp-server/main/src/duckduckgo_mcp_server/server.py
     - Configuration:
     ```
     {
         "mcpServers": {
-            "mcp-obsidian": {
-                "command": "npx",
+            "duckduckgo-mcp": {
+                "command": "uvx",
                 "args": [
-                    "-y",
-                    "@smithery/cli@latest",
-                    "run",
-                    "mcp-obsidian",
-                    "--config",
-                    "\"{\\\"vaultPath\\\":\\\"/absolute/path/to/your/vault\\\"}\""
+                    "duckduckgo-mcp-server"
                 ]
             }
         }
     }
     ```
-    Note: Set the `vaultPath` in the configuration to the absolute path of your Obsidian vault. No environment variables are required. Ensure the agent has read/write permissions to the specified vault directory. The configuration must use a valid absolute path for the vault, and the path should be accessible from the environment where the agent is running.
-
+    Note: Pay attention at the exact command and argument. You do NOT need an API key or token. The available tools are `search` for web search and `fetch_content` (to fetch and parse webpage content).
 
 2. ElevenLabs Text-to-Speech
     - Description: For text-to-speech and audio processing using ElevenLabs API
@@ -105,7 +97,7 @@ For each MCP server, you can also check available MCP tools from the provided li
     }
     }
     ```
-    
+
 5. GitHub
     - Description: For extracting and analysing data from GitHub repositories and automating GitHub workflows and processes.
     - Link to README: https://raw.githubusercontent.com/modelcontextprotocol/servers-archived/main/src/github/README.md

--- a/src/instructions.py
+++ b/src/instructions.py
@@ -51,7 +51,7 @@ WEBPAGE_DESCRIPTIONS = {
 CODE_EXAMPLE_WITH_COMMENTS = """
 # Example imports for the agent.py file:
 from any_agent import AnyAgent, AgentConfig, AgentFramework, TracingConfig
-from any_agent.tools import search_web, visit_webpage
+from any_agent.tools import search_tavily, visit_webpage
 from any_agent.config import MCPStdio
 from tools.review_code_with_llm import review_code_with_llm
 from pydantic import BaseModel, Field
@@ -75,7 +75,7 @@ agent = AnyAgent.create(
         model_id="gpt-4.1",
         instructions="Example instructions",
         tools=[
-            search_web, # Example tool available from any-agent library
+            search_tavily, # Example tool available from any-agent library
             review_code_with_llm, # Example tool taken from tools/available_tools.md
             # Example of MCP server usage
             MCPStdio(
@@ -147,7 +147,7 @@ using Mozilla's any-agent library. The implementation should:
 2. Implement a step-by-step approach where the agent breaks down the user's request into multiple steps, each with an input and output
 3. To obtain JSON output from the agent, define structured output using Pydantic v2 models via the output_type argument
 4. Whenever required, assign tools in the agent configuration. The tools available for you to assign are :
-    a. built-in tools from any-agent library: search_web, search_tavily and visit_webpage
+    a. built-in tools from any-agent library: search_tavily and visit_webpage
     b. python functions from the available_tools.md file
     c. MCPs from the available_mcps.md file
 
@@ -171,7 +171,7 @@ Refer to the any-agent documentation for valid parameters for AgentConfig.
 - You must choose tools from one of the following 3 options:
     a. Python Functions: The available tools are described in the local file at tools/available_tools.md - which can be read using `read_file` tool.
        Each tool in available_tools.md has a corresponding .py file in the tools/ directory that implements the function.
-    b. Tools pre-defined in any-agent library: `search_web`, `search_tavily` and `visit_webpage` tools
+    b. Tools pre-defined in any-agent library: `search_tavily` and `visit_webpage` tools
     c. MCPs: You can use MCPs to access external services. The available MCPs are described in the local file at mcps/available_mcps.md - which can be read using `read_file` tool.
        Each MCP has a configuration that must be accurately implemented in the agent configuration via MCPStdio().
        All information required to implement the MCP configuration is available in the mcps/available_mcps.md file.

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ import dotenv
 import fire
 from any_agent import AgentConfig, AgentFramework, AnyAgent
 from any_agent.config import MCPStdio
-from any_agent.tools import visit_webpage
+from any_agent.tools import visit_webpage, search_tavily
 from pydantic import BaseModel, Field
 from src.instructions import INSTRUCTIONS
 
@@ -40,23 +40,7 @@ def get_mount_config():
 def get_default_tools(mount_config):
     return [
         visit_webpage,
-        MCPStdio(
-            command="docker",
-            args=[
-                "run",
-                "-i",
-                "--rm",
-                "-e",
-                "BRAVE_API_KEY",
-                "mcp/brave-search",
-            ],
-            env={
-                "BRAVE_API_KEY": os.getenv("BRAVE_API_KEY"),
-            },
-            tools=[
-                "brave_web_search",
-            ],
-        ),
+        search_tavily,
         MCPStdio(
             command="docker",
             args=[


### PR DESCRIPTION
Closes #32 .

Something for everyone. Tested Tavily/DDG for basic workflows.

Replaces brave with tavily everywhere (agent creation, evaluation). Still gives the hint to ask for duckduckgo if needed.

Tavily is directly imported from any-agent. DDG could as well, but I left it to have the agent read the instructions on when to call it and to keep some example for folks. 
