### PR TITLE
Ignore directories in `latest` when archiving

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -179,7 +179,10 @@ def save_agent_trace(agent_trace, latest_dir):
 
 def archive_latest_run_artifacts(latest_dir, archive_dir):
     for item in latest_dir.iterdir():
-        shutil.copy(item, archive_dir / item.name)
+        if item.is_file():
+            shutil.copy(item, archive_dir / item.name)
+        else:
+            print(f"Skipping directory: {item.name}")
 
 
 def main(user_prompt: str, workflow_dir: Path | None = None):


### PR DESCRIPTION
Closes #52 by ignoring directories and copying over only the generated files as expected