### PR TITLE
(Bug fix) Make explicit in the instructions about tool use

### DIFF
--- a/src/instructions.py
+++ b/src/instructions.py
@@ -179,6 +179,7 @@ Refer to the any-agent documentation for valid parameters for AgentConfig.
        Always suggest only the minimum subset of tools from the MCP server URL that are necessary for the solving the task at hand.
        If the user's workflow requires file operations, you must include the filesystem MCPStdio() in the agent configuration.
        If the agent is required to generate any intermediate files, you may ask it to save them in a path relative to the current working directory (do not give absolute paths).
+To discover the tools and MCPs available, you MUST use the read_file tool to read the available_tools.md and available_mcps.md files.
 
 #### Structured Output (output_type via agent_args):
 - Define Pydantic v2 models to structure the agent's final output
@@ -216,7 +217,8 @@ Any-agent library enables you to:
 - Leverage built-in tools like web search and webpage visiting as well as MCP servers
 - Implement comprehensive tracing and evaluation capabilities
 
-You may access to the following webpages using `visit_webpage` tool:
+You may access to the following webpages using `visit_webpage` tool to further understand the any-agent library and its syntax.
+Before generating the code, ensure that you visit the necessary webpages for correct usage of any-agent library.
 
 {% for url, description in webpage_descriptions.items() %}
 - {{ url }}: {{ description }}

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,4 @@
 import json
-import os
 import shutil
 import uuid
 from datetime import datetime
@@ -9,7 +8,7 @@ import dotenv
 import fire
 from any_agent import AgentConfig, AgentFramework, AnyAgent
 from any_agent.config import MCPStdio
-from any_agent.tools import visit_webpage, search_tavily
+from any_agent.tools import search_tavily, visit_webpage
 from pydantic import BaseModel, Field
 from src.instructions import INSTRUCTIONS
 
@@ -60,6 +59,8 @@ def get_default_tools(mount_config):
             ],
             tools=[
                 "read_file",
+                "search_files",
+                "list_allowed_directories",
                 "list_directory",
             ],
         ),
@@ -145,10 +146,16 @@ def build_run_instructions(user_prompt):
     ## Tools
     You may use appropriate tools provided from tools/available_tools.md in the agent configuration.
     In addition to the tools pre-defined in available_tools.md,
-    two other tools that you could use are search_web and visit_webpage.
+    two other tools that you could use in the agent configuration are search_web, search_tavily and visit_webpage.
 
     ## MCPs
     You may use appropriate MCPs provided from mcps/available_mcps.md in the agent configuration.
+
+    You may use the following tools to browse and view the contents of the tools/ and mcps/ directories:
+    - list_directory tool to list the contents of the tools/ and mcps/ directories
+    - read_file tool to read the contents of the available_tools.md and available_mcps.md files
+    - search_files tool to recursively search for files/directories
+    - list_allowed_directories tool to list all directories that you have access to
 
     Generate python code for an agentic workflow using any-agent library to be able to do the following:
     {user_prompt}


### PR DESCRIPTION
After PR #40 , it seems that the code generator agent was not using the tools provided to it.

This could be observed in the form of `getting just one single output at the end of the process`
Previously, we used to see a series of steps taken by the agent in between the input and output. 

So here is what i tested with:
* use old instructions.py and new main.py -> :white_check_mark:  the intermediate steps show up
* use new instructions.py and new main.py -> :x:  no intermediate steps taken - e.g. does not read from available_tools
* use new instructions.py and old main.py ->  :x:  no intermediate steps taken - e.g. does not read from available_tools
Old = commit hash https://github.com/mozilla-ai/agent-factory/commit/632351f2a58eff9d54692dcf7589c52812fdd6c1
New = main after https://github.com/mozilla-ai/agent-factory/commit/e9908bfa02a5a60e3ec8104930d8bfeb4b03b8c6 merged

It seems that the changes in `instructions.py` from commit hash `e9908bfa02a5a60e3ec8104930d8bfeb4b03b8c6` caused the issue.

It is not 100% clear what part of the instructions changed to result in this new agent behavior (it probably has to do with the model or the agent framework). Shows the brittleness once again 😢 



