### PR TITLE
Add button to save generated workflow after multi-turn chat

### DIFF
--- a/src/chainlit_app.py
+++ b/src/chainlit_app.py
@@ -22,7 +22,6 @@ load_dotenv()
 repo_root = Path.cwd()
 workflows_root = repo_root / "generated_workflows"
 tools_dir = repo_root / "tools"
-mcps_dir = repo_root / "mcps"
 
 MCP_TOOLS = []
 
@@ -31,10 +30,8 @@ def get_mount_config():
     return {
         "host_workflows_dir": str(workflows_root),
         "host_tools_dir": str(tools_dir),
-        "host_mcps_dir": str(mcps_dir),
         "container_workflows_dir": "/app/generated_workflows",
         "container_tools_dir": "/app/tools",
-        "container_mcps_dir": "/app/mcps",
         "file_ops_dir": "/app",
     }
 


### PR DESCRIPTION
Exports code and intructions to `generated_workflows/latest` folder
![image](https://github.com/user-attachments/assets/0c09b60a-fd5c-46c9-85d2-d8906d9633fc)

It is possible to customize the button design with CSS styling (to make it more intuitive), but leaving it with the default styling for now!

To test:
* Carry out a multi-turn conversation similar to the testing instructions in #33 
   NOTE: If you are using `-w` or `--watch` flag when running the chainlit app, the window reloads to a fresh chat completion of the action, i.e., on clicking the save button (this is a chainlit bug? or feature? 😄 ). But with the regular `chainlit run src/chainlit_app.py`, you can continue the conversation to save intermediate versions 
* Once satisfied with the generated output, click the `Save Workflows` button 

Note: Sometimes it fails due to JSON parsing issues from the structured output.