### PR TITLE
feat: allow users to manually create their eval criteria

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -14,12 +14,13 @@
     "lint": "eslint src --ext .ts",
     "format": "prettier --write src"
   },
-  "packageManager": "pnpm@10.9.0",
+  "packageManager": "pnpm@10.12.1",
   "dependencies": {
     "@ai-sdk/openai": "^1.3.20",
     "ai": "^4.3.10",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "yaml": "^2.8.0",
     "zod": "^3.24.3"
   },
   "devDependencies": {

--- a/api/pnpm-lock.yaml
+++ b/api/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.1.0
+      yaml:
+        specifier: ^2.8.0
+        version: 2.8.0
       zod:
         specifier: ^3.24.3
         version: 3.25.48
@@ -1605,6 +1608,11 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yaml@2.8.0:
+    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3371,6 +3379,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  yaml@2.8.0: {}
 
   yocto-queue@0.1.0: {}
 

--- a/api/src/controllers/evaluation.controller.ts
+++ b/api/src/controllers/evaluation.controller.ts
@@ -224,24 +224,20 @@ export async function saveEvaluationCriteria(
 
     // Basic validation
     if (!criteriaData.llm_judge || !Array.isArray(criteriaData.checkpoints)) {
-      res
-        .status(400)
-        .json({
-          error:
-            'Invalid evaluation criteria format, llm_judge is missing or checkpoints is not an array',
-        })
+      res.status(400).json({
+        error:
+          'Invalid evaluation criteria format, llm_judge is missing or checkpoints is not an array',
+      })
       return
     }
 
     // Ensure all checkpoints have required fields
     for (const checkpoint of criteriaData.checkpoints) {
       if (!checkpoint.criteria || typeof checkpoint.points !== 'number') {
-        res
-          .status(400)
-          .json({
-            error:
-              'Invalid checkpoint format, a checkpoint doesnt have criteria or points is not a number',
-          })
+        res.status(400).json({
+          error:
+            'Invalid checkpoint format, a checkpoint doesnt have criteria or points is not a number',
+        })
         return
       }
     }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -16,6 +16,7 @@ import {
   runAgent,
   generateEvaluationCases,
   runEvaluation,
+  saveEvaluationCriteria,
 } from './controllers/evaluation.controller.js'
 import { listWorkflows } from './controllers/workflow.controller.js'
 import { sendInput, stopPythonProcess } from './controllers/input.controller.js'
@@ -50,6 +51,10 @@ app.post(
   generateEvaluationCases,
 )
 app.post('/agent-factory/evaluate/run-evaluation/:workflowPath', runEvaluation)
+app.post(
+  '/agent-factory/evaluate/save-criteria/:workflowPath',
+  saveEvaluationCriteria,
+)
 
 // Input and process control
 app.post('/agent-factory/input', sendInput)

--- a/api/src/services/evaluation.service.ts
+++ b/api/src/services/evaluation.service.ts
@@ -1,0 +1,38 @@
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import YAML from 'yaml'
+import { resolveWorkflowPath } from '../utils/path.utils.js'
+
+export interface EvaluationCheckpoint {
+  criteria: string
+  points: number
+}
+
+export interface EvaluationCriteria {
+  llm_judge: string
+  checkpoints: EvaluationCheckpoint[]
+}
+
+// Existing service functions...
+
+// Add new function to save evaluation criteria
+export async function saveEvaluationCriteria(
+  workflowPath: string,
+  criteriaData: EvaluationCriteria,
+): Promise<{ success: boolean; path: string }> {
+  const fullPath = resolveWorkflowPath(workflowPath)
+
+  // Convert to YAML
+  const yamlContent = YAML.stringify(criteriaData)
+
+  // Create file path
+  const criteriaFilePath = path.join(fullPath, 'evaluation_case.yaml')
+
+  // Write to file
+  await fs.writeFile(criteriaFilePath, yamlContent, 'utf8')
+
+  return {
+    success: true,
+    path: criteriaFilePath,
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "dotenv>=0.9.9",
     "pyyaml>=6.0.2",
     "chainlit>=2.5.5",
-    "mcpm>=1.0.3",  # installing a newer version of mcpm conflicts with the current version of chainlit (2.5.5)
+    "mcpm>=1.0.3", # installing a newer version of mcpm conflicts with the current version of chainlit (2.5.5)
     "loguru>=0.7.3",
+    "pre-commit>=4.2.0",
 ]

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,7 +29,8 @@
     "jwt-decode": "^4.0.0",
     "pinia": "^3.0.1",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.0"
+    "vue-router": "^4.5.0",
+    "yaml": "^2.8.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.51.1",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       vue-router:
         specifier: ^4.5.0
         version: 4.5.1(vue@3.5.13(typescript@5.8.3))
+      yaml:
+        specifier: ^2.8.0
+        version: 2.8.0
     devDependencies:
       '@playwright/test':
         specifier: ^1.51.1
@@ -59,10 +62,10 @@ importers:
         version: 22.15.3
       '@vitejs/plugin-vue':
         specifier: ^5.2.3
-        version: 5.2.3(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0))(vue@3.5.13(typescript@5.8.3))
+        version: 5.2.3(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0))(vue@3.5.13(typescript@5.8.3))
       '@vitest/eslint-plugin':
         specifier: ^1.1.39
-        version: 1.1.44(@typescript-eslint/utils@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3)(vitest@3.1.2(@types/node@22.15.3)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0))
+        version: 1.1.44(@typescript-eslint/utils@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3)(vitest@3.1.2(@types/node@22.15.3)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)(yaml@2.8.0))
       '@vue/eslint-config-prettier':
         specifier: ^10.2.0
         version: 10.2.0(eslint@9.25.1(jiti@2.4.2))(prettier@3.5.3)
@@ -107,16 +110,16 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^6.2.4
-        version: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)
+        version: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0)
       vite-plugin-pwa:
         specifier: ^1.0.0
-        version: 1.0.0(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0))(workbox-build@7.3.0)(workbox-window@7.3.0)
+        version: 1.0.0(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0))(workbox-build@7.3.0)(workbox-window@7.3.0)
       vite-plugin-vue-devtools:
         specifier: ^7.7.2
-        version: 7.7.6(rollup@2.79.2)(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0))(vue@3.5.13(typescript@5.8.3))
+        version: 7.7.6(rollup@2.79.2)(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0))(vue@3.5.13(typescript@5.8.3))
       vitest:
         specifier: ^3.1.1
-        version: 3.1.2(@types/node@22.15.3)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)
+        version: 3.1.2(@types/node@22.15.3)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)(yaml@2.8.0)
       vue-tsc:
         specifier: ^2.2.8
         version: 2.2.10(typescript@5.8.3)
@@ -3494,6 +3497,11 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@2.8.0:
+    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -4702,18 +4710,18 @@ snapshots:
       '@typescript-eslint/types': 8.31.1
       eslint-visitor-keys: 4.2.0
 
-  '@vitejs/plugin-vue@5.2.3(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0))(vue@3.5.13(typescript@5.8.3))':
+  '@vitejs/plugin-vue@5.2.3(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0))(vue@3.5.13(typescript@5.8.3))':
     dependencies:
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0)
       vue: 3.5.13(typescript@5.8.3)
 
-  '@vitest/eslint-plugin@1.1.44(@typescript-eslint/utils@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3)(vitest@3.1.2(@types/node@22.15.3)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0))':
+  '@vitest/eslint-plugin@1.1.44(@typescript-eslint/utils@8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3)(vitest@3.1.2(@types/node@22.15.3)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)(yaml@2.8.0))':
     dependencies:
       '@typescript-eslint/utils': 8.31.1(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.25.1(jiti@2.4.2)
     optionalDependencies:
       typescript: 5.8.3
-      vitest: 3.1.2(@types/node@22.15.3)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)
+      vitest: 3.1.2(@types/node@22.15.3)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)(yaml@2.8.0)
 
   '@vitest/expect@3.1.2':
     dependencies:
@@ -4722,13 +4730,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.2(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0))':
+  '@vitest/mocker@3.1.2(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.1.2':
     dependencies:
@@ -4854,14 +4862,14 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 7.7.6
 
-  '@vue/devtools-core@7.7.6(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0))(vue@3.5.13(typescript@5.8.3))':
+  '@vue/devtools-core@7.7.6(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0))(vue@3.5.13(typescript@5.8.3))':
     dependencies:
       '@vue/devtools-kit': 7.7.6
       '@vue/devtools-shared': 7.7.6
       mitt: 3.0.1
       nanoid: 5.1.5
       pathe: 2.0.3
-      vite-hot-client: 2.0.4(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0))
+      vite-hot-client: 2.0.4(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0))
       vue: 3.5.13(typescript@5.8.3)
     transitivePeerDependencies:
       - vite
@@ -6790,17 +6798,17 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-hot-client@2.0.4(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)):
+  vite-hot-client@2.0.4(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0)):
     dependencies:
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0)
 
-  vite-node@3.1.2(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0):
+  vite-node@3.1.2(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -6815,7 +6823,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-inspect@0.8.9(rollup@2.79.2)(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)):
+  vite-plugin-inspect@0.8.9(rollup@2.79.2)(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.4(rollup@2.79.2)
@@ -6826,39 +6834,39 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.1
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-pwa@1.0.0(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0))(workbox-build@7.3.0)(workbox-window@7.3.0):
+  vite-plugin-pwa@1.0.0(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0))(workbox-build@7.3.0)(workbox-window@7.3.0):
     dependencies:
       debug: 4.4.0
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.13
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0)
       workbox-build: 7.3.0
       workbox-window: 7.3.0
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-devtools@7.7.6(rollup@2.79.2)(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0))(vue@3.5.13(typescript@5.8.3)):
+  vite-plugin-vue-devtools@7.7.6(rollup@2.79.2)(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0))(vue@3.5.13(typescript@5.8.3)):
     dependencies:
-      '@vue/devtools-core': 7.7.6(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0))(vue@3.5.13(typescript@5.8.3))
+      '@vue/devtools-core': 7.7.6(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0))(vue@3.5.13(typescript@5.8.3))
       '@vue/devtools-kit': 7.7.6
       '@vue/devtools-shared': 7.7.6
       execa: 9.5.2
       sirv: 3.0.1
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)
-      vite-plugin-inspect: 0.8.9(rollup@2.79.2)(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0))
-      vite-plugin-vue-inspector: 5.3.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0))
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0)
+      vite-plugin-inspect: 0.8.9(rollup@2.79.2)(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0))
+      vite-plugin-vue-inspector: 5.3.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - rollup
       - supports-color
       - vue
 
-  vite-plugin-vue-inspector@5.3.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)):
+  vite-plugin-vue-inspector@5.3.1(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0)):
     dependencies:
       '@babel/core': 7.27.1
       '@babel/plugin-proposal-decorators': 7.27.1(@babel/core@7.27.1)
@@ -6869,11 +6877,11 @@ snapshots:
       '@vue/compiler-dom': 3.5.13
       kolorist: 1.8.0
       magic-string: 0.30.17
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0):
+  vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.3
       fdir: 6.4.4(picomatch@4.0.2)
@@ -6886,11 +6894,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.4.2
       terser: 5.39.0
+      yaml: 2.8.0
 
-  vitest@3.1.2(@types/node@22.15.3)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0):
+  vitest@3.1.2(@types/node@22.15.3)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)(yaml@2.8.0):
     dependencies:
       '@vitest/expect': 3.1.2
-      '@vitest/mocker': 3.1.2(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0))
+      '@vitest/mocker': 3.1.2(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0))
       '@vitest/pretty-format': 3.1.2
       '@vitest/runner': 3.1.2
       '@vitest/snapshot': 3.1.2
@@ -6907,8 +6916,8 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)
-      vite-node: 3.1.2(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0)
+      vite-node: 3.1.2(@types/node@22.15.3)(jiti@2.4.2)(terser@5.39.0)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.15.3
@@ -7186,6 +7195,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.8.0: {}
 
   yocto-queue@0.1.0: {}
 

--- a/ui/src/assets/base.css
+++ b/ui/src/assets/base.css
@@ -62,6 +62,30 @@
 
   --scrollbar-thumb: #d1d5db;
   --scrollbar-track: #f3f4f6;
+
+  /* Primary & Secondary Colors */
+  --color-primary: #3a8ee6;
+  --color-primary-soft: rgba(58, 142, 230, 0.15);
+  --color-primary-hover: #2c7be5;
+
+  --color-secondary: #6c757d;
+  --color-secondary-soft: rgba(108, 117, 125, 0.15);
+  --color-secondary-hover: #5a6268;
+
+  /* Success colors - green tones */
+  --color-success: #2ecc71;
+  --color-success-soft: rgba(46, 204, 113, 0.15);
+  --color-success-hover: #27ae60;
+
+  /* Error colors - red tones */
+  --color-error: #e74c3c;
+  --color-error-soft: rgba(231, 76, 60, 0.15);
+  --color-error-hover: #c0392b;
+
+  /* Warning colors - yellow/orange tones */
+  --color-warning: #f39c12;
+  --color-warning-soft: rgba(243, 156, 18, 0.15);
+  --color-warning-hover: #e67e22;
 }
 
 .theme-dark {
@@ -102,6 +126,30 @@
 
   --scrollbar-thumb: #374151;
   --scrollbar-track: #232b3a;
+
+  /* Primary & Secondary Colors */
+  --color-primary: #4d96f0;
+  --color-primary-soft: rgba(77, 150, 240, 0.2);
+  --color-primary-hover: #3a8ee6;
+
+  --color-secondary: #adb5bd;
+  --color-secondary-soft: rgba(173, 181, 189, 0.2);
+  --color-secondary-hover: #98a2ac;
+
+  /* Success colors - adjusted for dark mode */
+  --color-success: #4cd137;
+  --color-success-soft: rgba(76, 209, 55, 0.2);
+  --color-success-hover: #44bd32;
+
+  /* Error colors - adjusted for dark mode */
+  --color-error: #ff6b6b;
+  --color-error-soft: rgba(255, 107, 107, 0.2);
+  --color-error-hover: #ee5253;
+
+  /* Warning colors - adjusted for dark mode */
+  --color-warning: #ffa502;
+  --color-warning-soft: rgba(255, 165, 2, 0.2);
+  --color-warning-hover: #ff9f1a;
 }
 
 *,

--- a/ui/src/components/EvaluationCriteriaForm.vue
+++ b/ui/src/components/EvaluationCriteriaForm.vue
@@ -1,0 +1,318 @@
+<template>
+  <div class="evaluation-criteria-form">
+    <h3>{{ initialData ? 'Edit' : 'Create' }} Evaluation Criteria</h3>
+
+    <form @submit.prevent="handleSubmit">
+      <div class="form-group">
+        <label for="llm-judge">LLM Judge</label>
+        <select id="llm-judge" v-model="formData.llm_judge" required>
+          <option value="openai/gpt-4.1">OpenAI GPT-4.1</option>
+          <option value="openai/gpt-4">OpenAI GPT-4</option>
+          <option value="anthropic/claude-3-opus">Anthropic Claude 3 Opus</option>
+          <option value="anthropic/claude-3-sonnet">Anthropic Claude 3 Sonnet</option>
+        </select>
+      </div>
+
+      <div class="checkpoints-section">
+        <h4>Evaluation Checkpoints</h4>
+        <p class="help-text">Define the criteria used to evaluate agent performance</p>
+
+        <div
+          v-for="(checkpoint, index) in formData.checkpoints"
+          :key="index"
+          class="checkpoint-item"
+        >
+          <div class="checkpoint-header">
+            <div class="checkpoint-number">{{ index + 1 }}</div>
+            <div class="checkpoint-actions">
+              <button
+                type="button"
+                class="delete-button"
+                @click="removeCheckpoint(index)"
+                aria-label="Remove checkpoint"
+              >
+                <span aria-hidden="true">×</span>
+              </button>
+            </div>
+          </div>
+
+          <div class="checkpoint-content">
+            <div class="form-group">
+              <label :for="`criteria-${index}`">Criteria</label>
+              <textarea
+                :id="`criteria-${index}`"
+                v-model="checkpoint.criteria"
+                rows="3"
+                placeholder="Describe what the agent should accomplish"
+                required
+              ></textarea>
+            </div>
+
+            <div class="form-group">
+              <label :for="`points-${index}`">Points</label>
+              <input
+                :id="`points-${index}`"
+                type="number"
+                v-model.number="checkpoint.points"
+                min="1"
+                max="10"
+                required
+              />
+            </div>
+          </div>
+        </div>
+
+        <button type="button" class="add-checkpoint-button" @click="addCheckpoint">
+          Add Checkpoint
+        </button>
+      </div>
+
+      <div class="form-actions">
+        <button type="button" class="cancel-button" @click="emit('cancel')">Cancel</button>
+        <button type="submit" class="save-button" :disabled="saveMutation.isPending.value">
+          {{ saveMutation.isPending.value ? 'Saving...' : 'Save Criteria' }}
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, onMounted } from 'vue'
+import { useMutation, useQueryClient } from '@tanstack/vue-query'
+import { saveEvaluationCriteria } from '../services/evaluationService'
+import type { EvaluationCriteria } from '../types/evaluation'
+
+const props = defineProps<{
+  workflowId: string
+  initialData?: EvaluationCriteria | null
+}>()
+
+const emit = defineEmits<{
+  saved: [success: boolean]
+  cancel: []
+}>()
+
+const queryClient = useQueryClient()
+
+// Initialize with default empty structure or provided data
+const formData = reactive<EvaluationCriteria>({
+  llm_judge: 'openai/gpt-4.1',
+  checkpoints: [
+    {
+      criteria: '',
+      points: 2,
+    },
+  ],
+})
+
+// Initialize from props if provided
+onMounted(() => {
+  if (props.initialData) {
+    formData.llm_judge = props.initialData.llm_judge
+    formData.checkpoints = [...props.initialData.checkpoints]
+  }
+})
+
+const addCheckpoint = () => {
+  formData.checkpoints.push({
+    criteria: '',
+    points: 2,
+  })
+}
+
+const removeCheckpoint = (index: number) => {
+  formData.checkpoints.splice(index, 1)
+
+  // Ensure at least one checkpoint exists
+  if (formData.checkpoints.length === 0) {
+    addCheckpoint()
+  }
+}
+
+// Use TanStack Query mutation for saving
+const saveMutation = useMutation({
+  mutationFn: async () => {
+    return await saveEvaluationCriteria(props.workflowId, formData)
+  },
+  onSuccess: () => {
+    // Invalidate the criteria query to refresh data
+    queryClient.invalidateQueries({
+      queryKey: ['evaluationCriteria', props.workflowId],
+    })
+    emit('saved', true)
+  },
+  onError: (error) => {
+    console.error('Failed to save criteria:', error)
+    emit('saved', false)
+  },
+})
+
+const handleSubmit = () => {
+  saveMutation.mutate()
+}
+</script>
+
+<style scoped>
+.evaluation-criteria-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+label {
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+input,
+textarea,
+select {
+  padding: 0.75rem;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-background);
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: 1rem;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  outline: 2px solid var(--color-border-hover);
+  border-color: var(--color-border-hover);
+}
+
+.checkpoints-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.help-text {
+  color: var(--color-text-light);
+  font-size: 0.9rem;
+}
+
+.checkpoint-item {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: var(--color-background-soft);
+}
+
+.checkpoint-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  background-color: var(--color-background-soft);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.checkpoint-number {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  background-color: var(--color-background);
+  border-radius: 50%;
+  font-weight: bold;
+  border: 1px solid var(--color-border);
+}
+
+.checkpoint-content {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.checkpoint-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.delete-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-background);
+  color: var(--color-text);
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.delete-button:hover {
+  background-color: rgba(231, 76, 60, 0.15);
+  color: var(--color-error, #e74c3c);
+  border-color: var(--color-error, #e74c3c);
+}
+
+.add-checkpoint-button {
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  border: 1px dashed var(--color-border);
+  background-color: var(--color-background);
+  color: var(--color-text);
+  cursor: pointer;
+  text-align: center;
+  font-weight: 500;
+}
+
+.add-checkpoint-button:hover {
+  border-color: var(--color-border-hover);
+  background-color: var(--color-background-soft);
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.cancel-button {
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-background);
+  color: var(--color-text);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.cancel-button:hover {
+  background-color: var(--color-background-soft);
+}
+
+.save-button {
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  border: none;
+  background-color: var(--color-success, #2ecc71);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.save-button:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.save-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+</style>

--- a/ui/src/components/EvaluationCriteriaForm.vue
+++ b/ui/src/components/EvaluationCriteriaForm.vue
@@ -1,7 +1,15 @@
 <template>
   <div class="evaluation-criteria-form">
     <h3>{{ initialData ? 'Edit' : 'Create' }} Evaluation Criteria</h3>
-
+    <!-- Add this warning before the form actions -->
+    <div class="form-warning">
+      <div class="warning-icon">⚠️</div>
+      <div class="warning-text">
+        <strong>Warning:</strong> Saving criteria will invalidate any existing evaluation results
+        for this workflow. Previous results will be deleted as they would no longer match the
+        updated criteria.
+      </div>
+    </div>
     <form @submit.prevent="handleSubmit">
       <div class="form-group">
         <label for="llm-judge">LLM Judge</label>
@@ -78,7 +86,7 @@
 
 <script setup lang="ts">
 import { reactive, onMounted } from 'vue'
-import { useMutation, useQueryClient } from '@tanstack/vue-query'
+import { useMutation } from '@tanstack/vue-query'
 import { saveEvaluationCriteria } from '../services/evaluationService'
 import type { EvaluationCriteria } from '../types/evaluation'
 
@@ -91,8 +99,6 @@ const emit = defineEmits<{
   saved: [success: boolean]
   cancel: []
 }>()
-
-const queryClient = useQueryClient()
 
 // Initialize with default empty structure or provided data
 const formData = reactive<EvaluationCriteria>({
@@ -148,7 +154,13 @@ const handleSubmit = () => {
 .evaluation-criteria-form {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1rem;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .form-group {
@@ -268,6 +280,28 @@ select:focus {
   background-color: var(--color-background-soft);
 }
 
+/* Add these styles for the warning message */
+.form-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  background-color: rgba(243, 156, 18, 0.1);
+  border-left: 4px solid #f39c12;
+  border-radius: 4px;
+}
+
+.warning-icon {
+  font-size: 1.25rem;
+  line-height: 1.2;
+}
+
+.warning-text {
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+
 .form-actions {
   display: flex;
   justify-content: flex-end;
@@ -292,8 +326,6 @@ select:focus {
   padding: 0.75rem 1.5rem;
   border-radius: 6px;
   border: none;
-  background-color: var(--color-success, #2ecc71);
-  color: #fff;
   font-weight: 600;
   cursor: pointer;
 }

--- a/ui/src/components/EvaluationCriteriaForm.vue
+++ b/ui/src/components/EvaluationCriteriaForm.vue
@@ -55,7 +55,6 @@
                 type="number"
                 v-model.number="checkpoint.points"
                 min="1"
-                max="10"
                 required
               />
             </div>
@@ -84,7 +83,7 @@ import { saveEvaluationCriteria } from '../services/evaluationService'
 import type { EvaluationCriteria } from '../types/evaluation'
 
 const props = defineProps<{
-  workflowId: string
+  workflowPath: string
   initialData?: EvaluationCriteria | null
 }>()
 
@@ -123,23 +122,15 @@ const addCheckpoint = () => {
 
 const removeCheckpoint = (index: number) => {
   formData.checkpoints.splice(index, 1)
-
-  // Ensure at least one checkpoint exists
-  if (formData.checkpoints.length === 0) {
-    addCheckpoint()
-  }
 }
 
 // Use TanStack Query mutation for saving
 const saveMutation = useMutation({
   mutationFn: async () => {
-    return await saveEvaluationCriteria(props.workflowId, formData)
+    return await saveEvaluationCriteria(props.workflowPath, formData)
   },
   onSuccess: () => {
     // Invalidate the criteria query to refresh data
-    queryClient.invalidateQueries({
-      queryKey: ['evaluationCriteria', props.workflowId],
-    })
     emit('saved', true)
   },
   onError: (error) => {

--- a/ui/src/components/EvaluationCriteriaViewer.vue
+++ b/ui/src/components/EvaluationCriteriaViewer.vue
@@ -17,7 +17,7 @@
       class="criteria-form-container"
     >
       <EvaluationCriteriaForm
-        :workflowId="workflowId"
+        :workflow-path="workflowPath"
         :initialData="evaluationCriteriaQuery.data.value"
         @saved="onCriteriaSaved"
         @cancel="isEditMode = false"
@@ -135,7 +135,6 @@ interface EvaluationResults {
 // Props
 const props = defineProps<{
   workflowPath: string
-  workflowId: string
 }>()
 
 const queryClient = useQueryClient()
@@ -151,6 +150,7 @@ const onCriteriaSaved = () => {
   isEditMode.value = false
   // Refetch the criteria to update the view
   queryClient.invalidateQueries({ queryKey: ['evaluation-criteria', props.workflowPath] })
+  queryClient.invalidateQueries({ queryKey: ['evaluation-results', props.workflowPath] })
 }
 
 // Fetch evaluation criteria

--- a/ui/src/components/EvaluationPanel.vue
+++ b/ui/src/components/EvaluationPanel.vue
@@ -141,7 +141,7 @@ const runAgentMutation = useMutation({
   onSuccess: () => {
     console.log('Agent run successful, invalidating evaluation status query')
     queryClient.invalidateQueries({
-      queryKey: ['evaluationStatus', props.workflowPath],
+      queryKey: ['evaluation-status', props.workflowPath],
     })
     emit('evaluation-status-changed', {
       hasAgentTrace: true,
@@ -169,7 +169,7 @@ const genCasesMutation = useMutation({
   onSuccess: () => {
     console.log('Case generation successful, invalidating cases query')
     queryClient.invalidateQueries({
-      queryKey: ['evaluationStatus', props.workflowPath],
+      queryKey: ['evaluation-status', props.workflowPath],
     })
     emit('evaluation-status-changed', {
       hasEvalCases: true,
@@ -197,7 +197,7 @@ const runEvalMutation = useMutation({
   onSuccess: () => {
     console.log('Evaluation successful, invalidating results query')
     queryClient.invalidateQueries({
-      queryKey: ['evaluationStatus', props.workflowPath],
+      queryKey: ['evaluation-status', props.workflowPath],
     })
     emit('evaluation-status-changed', {
       hasEvalResults: true,

--- a/ui/src/components/ResultsViewer.vue
+++ b/ui/src/components/ResultsViewer.vue
@@ -149,14 +149,14 @@ const router = useRouter()
 
 // Fetch evaluation status using workflowService
 const statusQuery = useQuery({
-  queryKey: ['evaluationStatus', props.workflowPath],
+  queryKey: ['evaluation-status', props.workflowPath],
   queryFn: () => workflowService.getEvaluationStatus(props.workflowPath),
   retry: 1,
 })
 
 // Fetch evaluation results using API client instead of direct fetch
 const resultsQuery = useQuery({
-  queryKey: ['evaluationResults', props.workflowPath],
+  queryKey: ['evaluation-results', props.workflowPath],
   queryFn: () => workflowService.getEvaluationResults(props.workflowPath),
   retry: 1,
 })

--- a/ui/src/services/evaluationService.ts
+++ b/ui/src/services/evaluationService.ts
@@ -1,4 +1,5 @@
 import { apiClient } from './api'
+import type { EvaluationCriteria, SaveCriteriaResponse } from '../types/evaluation'
 
 export const evaluationService = {
   async runAgent(workflowPath: string): Promise<ReadableStream> {
@@ -39,4 +40,24 @@ export const evaluationService = {
 
     return response.body as ReadableStream
   },
+}
+
+export async function fetchEvaluationCriteria(workflowId: string): Promise<EvaluationCriteria> {
+  const path = workflowId === 'latest' ? 'latest' : `archive/${workflowId}`
+
+  const response = await apiClient.get(`/agent-factory/workflows/${path}/evaluation_case.yaml`)
+  return response.data
+}
+
+export async function saveEvaluationCriteria(
+  workflowId: string,
+  criteriaData: EvaluationCriteria,
+): Promise<SaveCriteriaResponse> {
+  const path = workflowId === 'latest' ? 'latest' : `archive/${workflowId}`
+
+  const response = await apiClient.post(
+    `/agent-factory/evaluate/save-criteria/${path}`,
+    criteriaData,
+  )
+  return response.data
 }

--- a/ui/src/types/evaluation.ts
+++ b/ui/src/types/evaluation.ts
@@ -1,0 +1,21 @@
+export interface EvaluationCheckpoint {
+  criteria: string
+  points: number
+}
+
+export interface EvaluationCriteria {
+  llm_judge: string
+  checkpoints: EvaluationCheckpoint[]
+}
+
+export interface EvaluationResult {
+  criteria: string
+  result: 'pass' | 'fail'
+  feedback: string
+}
+
+export interface SaveCriteriaResponse {
+  success: boolean
+  message: string
+  path: string
+}

--- a/ui/src/views/FileView.vue
+++ b/ui/src/views/FileView.vue
@@ -66,7 +66,7 @@ const fileName = computed(() => {
 })
 
 const fileQuery = useQuery({
-  queryKey: ['fileContent', filePath],
+  queryKey: ['file-content', filePath],
   queryFn: async () => {
     const response = await fetch(`http://localhost:3000/agent-factory/workflows/${filePath.value}`)
 

--- a/ui/src/views/WorkflowDetailsView.vue
+++ b/ui/src/views/WorkflowDetailsView.vue
@@ -72,7 +72,7 @@ const workflowPath = computed(() => {
 
 // Setup evaluation status checking
 const evaluationStatusQuery = useQuery({
-  queryKey: ['evaluationStatus', workflowPath],
+  queryKey: ['evaluation-status', workflowPath],
   queryFn: () => workflowService.getEvaluationStatus(workflowPath.value),
   enabled: computed(() => !!workflowPath.value),
   retry: 1,
@@ -91,7 +91,7 @@ const selectedFilePath = computed(() =>
 
 // Configure file content query with caching
 const fileContentQuery = useQuery({
-  queryKey: ['fileContent', workflowPath, selectedFilePath],
+  queryKey: ['file-content', workflowPath, selectedFilePath],
   queryFn: () => {
     // Make sure we have both required parameters as strings
     if (!workflowPath.value || !selectedFilePath.value) {

--- a/ui/src/views/WorkflowDetailsView.vue
+++ b/ui/src/views/WorkflowDetailsView.vue
@@ -119,9 +119,9 @@ const availableTabs = computed(() => {
     tabs.push({ id: 'agent-trace', label: 'Agent Trace' })
   }
 
-  if (evaluationStatusQuery.data.value?.hasEvalCases) {
-    tabs.push({ id: 'criteria', label: 'Evaluation Criteria' })
-  }
+  // if (evaluationStatusQuery.data.value?.hasEvalCases) {
+  tabs.push({ id: 'criteria', label: 'Evaluation Criteria' })
+  // }
 
   if (
     evaluationStatusQuery.data.value?.hasAgentTrace ||

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -20,6 +19,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "loguru" },
     { name = "mcpm" },
+    { name = "pre-commit" },
     { name = "pyyaml" },
 ]
 
@@ -32,6 +32,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.2" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcpm", specifier = ">=1.0.3" },
+    { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
 ]
 
@@ -391,6 +392,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249 },
+]
+
+[[package]]
 name = "chainlit"
 version = "2.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -608,6 +618,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/db/04/d24f6e645ad82ba0ef092fa17d9ef7a21953781663648a01c9371d9e8e98/dirtyjson-1.0.8.tar.gz", hash = "sha256:90ca4a18f3ff30ce849d100dcf4a003953c79d3a2348ef056f1d9c22231a25fd", size = 30782 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/69/1bcf70f81de1b4a9f21b3a62ec0c83bdff991c88d6cc2267d02408457e88/dirtyjson-1.0.8-py3-none-any.whl", hash = "sha256:125e27248435a58acace26d5c2c4c11a1c0de0a9c5124c5a94ba78e517d74f53", size = 25197 },
+]
+
+[[package]]
+name = "distlib"
+version = "0.3.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973 },
 ]
 
 [[package]]
@@ -1339,6 +1358,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3b/7b/09ab792c463975fcd0a81f459b5e900057dabbbc274ff253bb28d58ebfce/huggingface_hub-0.31.2.tar.gz", hash = "sha256:7053561376ed7f6ffdaecf09cc54d70dc784ac6315fa4bb9b93e19662b029675", size = 403025 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/81/a8fd9c226f7e3bc8918f1e456131717cb38e93f18ccc109bf3c8471e464f/huggingface_hub-0.31.2-py3-none-any.whl", hash = "sha256:8138cd52aa2326b4429bb00a4a1ba8538346b7b8a808cdce30acb6f1f1bdaeec", size = 484230 },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/88/d193a27416618628a5eea64e3223acd800b40749a96ffb322a9b55a49ed1/identify-2.6.12.tar.gz", hash = "sha256:d8de45749f1efb108badef65ee8386f0f7bb19a7f26185f74de6367bffbaf0e6", size = 99254 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/cd/18f8da995b658420625f7ef13f037be53ae04ec5ad33f9b718240dcfd48c/identify-2.6.12-py2.py3-none-any.whl", hash = "sha256:ad9672d5a72e0d2ff7c5c8809b62dfa60458626352fb0eb7b55e69bdc45334a2", size = 99145 },
 ]
 
 [[package]]
@@ -2327,6 +2355,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3c/87/db8be88ad32c2d042420b6fd9ffd4a149f9a0d7f0e86b3f543be2eeeedd2/nltk-3.9.1.tar.gz", hash = "sha256:87d127bd3de4bd89a4f81265e5fa59cb1b199b27440175370f7417d2bc7ae868", size = 2904691 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/66/7d9e26593edda06e8cb531874633f7c2372279c3b0f46235539fe546df8b/nltk-3.9.1-py3-none-any.whl", hash = "sha256:4fa26829c5b00715afe3061398a8989dc643b92ce7dd93fb4585a70930d168a1", size = 1505442 },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
 ]
 
 [[package]]
@@ -3332,6 +3369,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/a9/ec3bbc23b6f3c23c52e0b5795b1357cca74aa5cfb254213f1e471fef9b4d/posthog-3.25.0.tar.gz", hash = "sha256:9168f3e7a0a5571b6b1065c41b3c171fbc68bfe72c3ac0bfd6e3d2fcdb7df2ca", size = 75968 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/e2/c158366e621562ef224f132e75c1d1c1fce6b078a19f7d8060451a12d4b9/posthog-3.25.0-py2.py3-none-any.whl", hash = "sha256:85db78c13d1ecb11aed06fad53759c4e8fb3633442c2f3d0336bc0ce8a585d30", size = 89115 },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707 },
 ]
 
 [[package]]
@@ -4513,6 +4566,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a6/ae/9bbb19b9e1c450cf9ecaef06463e40234d98d95bf572fab11b4f19ae5ded/uvicorn-0.34.2.tar.gz", hash = "sha256:0e929828f6186353a80b58ea719861d2629d766293b6d19baf086ba31d4f3328", size = 76815 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/4b/4cef6ce21a2aaca9d852a6e84ef4f135d99fcd74fa75105e2fc0c8308acd/uvicorn-0.34.2-py3-none-any.whl", hash = "sha256:deb49af569084536d269fe0a6d67e3754f104cf03aba7c11c40f01aadf33c403", size = 62483 },
+]
+
+[[package]]
+name = "virtualenv"
+version = "20.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/2c/444f465fb2c65f40c3a104fd0c495184c4f2336d65baf398e3c75d72ea94/virtualenv-20.31.2.tar.gz", hash = "sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af", size = 6076316 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/40/b1c265d4b2b62b58576588510fc4d1fe60a86319c8de99fd8e9fec617d2c/virtualenv-20.31.2-py3-none-any.whl", hash = "sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11", size = 6057982 },
 ]
 
 [[package]]


### PR DESCRIPTION
## API

1. Add a new endpoint to submit evaluation cases, parse as yaml and write to `evaluation_case.yaml`, and delete `evaluation-results.json` if any

## UI

1. Add a new "Edit criteria" button to edit an existing workflow's evaluation cases
<img width="1170" alt="image" src="https://github.com/user-attachments/assets/1df47cb7-6171-46f2-be04-98ae5aea4466" />
2. Create a new EvaluationCriteriaForm component where users can edit the evaluation cases
<img width="1174" alt="image" src="https://github.com/user-attachments/assets/61523653-7b38-4494-9e61-dbe49f60ae3d" />
3. For workflows that have no `evaluation_case.yaml` file, the form to create one will be shown instead
4. Editing eval criteria will delete any previous evaluation results as they become invalidated/obsolete, users will need to run the evaluation again manually to see the latest results
