### PR TITLE
Change the default MCP Server registry

### DIFF
--- a/src/agent_factory/tools.py
+++ b/src/agent_factory/tools.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from mcpm.utils.repository import RepositoryManager
 
-DEFAULT_REGISTRY_URL = "https://mcpm.sh/api/servers.json"
+DEFAULT_REGISTRY_URL = "https://getmcp.io/api/servers.json"
 
 KEYS_TO_DROP = ("display_name", "repository", "homepage", "author", "categories", "tags", "docker_url", "examples")
 


### PR DESCRIPTION
According to [pathintegral-institute/mcpm.sh#154](https://github.com/pathintegral-institute/mcpm.sh/issues/154) the registry at [getmcp.io](getmcp.io) has been developed with compatibility with the official MCP registry.

Change the default registry to `getmcp.io/api/servers.json`.