### PR TITLE
Tests to check if generated requirements file is valid and installable

### DIFF
--- a/tests/generation/test_single_turn_generation.py
+++ b/tests/generation/test_single_turn_generation.py
@@ -1,4 +1,6 @@
 import ast
+import subprocess
+import tempfile
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from shutil import copytree
@@ -18,6 +20,47 @@ def _assert_agent_syntax(agent_file: Path):
     ast.parse(agent_file.read_text(encoding="utf-8"))
 
 
+def _assert_requirements_installable(requirements_path: Path, timeout: int = 180):
+    """Verify that the requirements can be installed in a clean environment.
+
+    Args:
+        requirements_path: Path to the requirements.txt file
+        timeout: Maximum time in seconds to wait for installation
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        env_dir = Path(temp_dir) / ".venv"
+
+        try:
+            # Create a new virtual environment
+            subprocess.run(
+                ["uv", "venv", str(env_dir), "--python=python3.11"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+
+            # Install requirements
+            result = subprocess.run(
+                ["uv", "pip", "install", "-r", str(requirements_path)],
+                check=False,
+                cwd=temp_dir,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+
+            assert result.returncode == 0, (
+                f"Failed to install requirements:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+            )
+        except subprocess.TimeoutExpired:
+            raise AssertionError(f"Requirements installation timed out after {timeout} seconds") from None
+        except subprocess.CalledProcessError as e:
+            raise AssertionError(
+                f"Failed to create virtual environment:\nSTDOUT: {e.stdout}\nSTDERR: {e.stderr}"
+            ) from e
+
+
 @pytest.mark.parametrize(
     ("prompt_id", "prompt"),
     [
@@ -35,7 +78,11 @@ def test_single_turn_generation(tmp_path: Path, prompt_id: str, prompt: str, req
 
     _assert_generated_files(tmp_path)
 
+    # Verify the generated agent.py has valid Python syntax
     _assert_agent_syntax(tmp_path / "agent.py")
+
+    # Verify requirements can be installed in a clean environment
+    _assert_requirements_installable(tmp_path / "requirements.txt")
 
     update_artifacts = request.config.getoption("--update-artifacts")
 


### PR DESCRIPTION
Some additional tests such as:
* Verifies the first line of requirements.txt matches any-agent[all]=={version}
* Use regex to detect MCP tool usage which is based on `uvx` in agent.py - if yes, check if 'uv' is in requirements.txt. Additionally, ensure `uv` is not present when uvx MCP is not used 