### PR TITLE
feat: add eval generation cost to ui

### DIFF
--- a/ui/src/components/EvaluationCriteriaForm.vue
+++ b/ui/src/components/EvaluationCriteriaForm.vue
@@ -123,6 +123,11 @@ const formData = reactive<EvaluationCriteria>({
       points: 1,
     },
   ],
+  evaluation_case_generation_costs: {
+    input_cost: 0,
+    output_cost: 0,
+    total_cost: 0,
+  },
 })
 
 const formErrors = ref({

--- a/ui/src/components/tabs/EvaluationCriteriaViewer.vue
+++ b/ui/src/components/tabs/EvaluationCriteriaViewer.vue
@@ -49,6 +49,18 @@
             <span class="points-label">Total Points Possible:</span>
             <span class="points-value">{{ totalPossiblePoints }}</span>
           </div>
+          <div
+            class="cost-info"
+            v-if="evaluationCriteriaQuery.data.value.evaluation_case_generation_costs"
+          >
+            <span class="cost-label"
+              >Evaluation Case Generation Cost: ${{
+                evaluationCriteriaQuery.data.value.evaluation_case_generation_costs.total_cost.toFixed(
+                  2,
+                )
+              }}</span
+            >
+          </div>
         </div>
 
         <div class="header-actions">
@@ -121,16 +133,7 @@ import { useDeleteConfirmation } from '@/composables/useDeleteConfirmation'
 import { useQueryInvalidation } from '@/composables/useQueryInvalidation'
 import { useNavigation } from '@/composables/useNavigation'
 import { queryKeys } from '@/helpers/queryKeys'
-
-interface Checkpoint {
-  criteria: string
-  points: number
-}
-
-interface EvaluationCriteria {
-  llm_judge?: string
-  checkpoints: Checkpoint[]
-}
+import type { EvaluationCriteria } from '@/types'
 
 // Props
 const props = defineProps<{

--- a/ui/src/components/tabs/EvaluationResultsViewer.vue
+++ b/ui/src/components/tabs/EvaluationResultsViewer.vue
@@ -172,6 +172,11 @@ const criteriaQuery = useQuery({
       return {
         llm_judge: 'N/A',
         checkpoints: [],
+        evaluation_case_generation_costs: {
+          input_cost: 0,
+          output_cost: 0,
+          total_cost: 0,
+        },
       }
     }
   },

--- a/ui/src/services/evaluationService.ts
+++ b/ui/src/services/evaluationService.ts
@@ -9,6 +9,11 @@ import type { EvaluationCriteria, SaveCriteriaResponse } from '@/types/index'
 // Simple evaluation case format with just criteria strings
 interface SimpleCriteriaFormat {
   criteria: string[]
+  evaluation_case_generation_costs: {
+    input_cost: number
+    output_cost: number
+    total_cost: number
+  }
 }
 
 // Transform function to convert simple format to full UI format
@@ -19,6 +24,7 @@ function transformToUIFormat(simpleFormat: SimpleCriteriaFormat): EvaluationCrit
       criteria: criterion,
       points: 1, // Default fallback value
     })),
+    evaluation_case_generation_costs: simpleFormat.evaluation_case_generation_costs,
   }
 }
 

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -33,6 +33,11 @@ export interface EvaluationCheckpoint {
 export interface EvaluationCriteria {
   llm_judge?: string // Optional since new format doesn't always include it
   checkpoints: EvaluationCheckpoint[]
+  evaluation_case_generation_costs: {
+    input_cost: number
+    output_cost: number
+    total_cost: number
+  }
 }
 
 export interface EvaluationResult {


### PR DESCRIPTION
## 📝 What's changing

Added eval generation cost to ui

## 📚 How to test it

Steps to test the changes:

1. Go to a created agent --> Run Eval Tab --> Generate Evaluation cases (or use an agent where you already generated them using the cli)
2. Cost should be added to the header

---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [ ] Added some tests for any new functionality
- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully

---

## 📸 Screenshots (if applicable)

<img width="1157" alt="image" src="https://github.com/user-attachments/assets/00eb701e-8544-430a-9a65-d5ae5a73cbd4" />

