### PR TITLE
refactor: cleanup references to latest/ directory in eval instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This will run the agent and save the agent trace as `agent_eval_trace.json` in t
 
 Run the evaluation case generator agent with your desired evaluation case prompt:
 ```bash
-python -m eval.generate_evaluation_case
+python -m eval.generate_evaluation_case generated_workflows/latest
 ```
 
 This will generate a JSON file in the `generated_workflows/latest` directory with evaluation criteria.
@@ -113,7 +113,7 @@ This will generate a JSON file in the `generated_workflows/latest` directory wit
 Evaluate the agent's execution trace against the generated evaluation case:
 
 ```bash
-python -m eval.run_generated_agent_evaluation
+python -m eval.run_generated_agent_evaluation  generated_workflows/latest
 ```
 This will display the evaluation criteria and show how the agent performed on each.
 

--- a/api/src/services/evaluation.service.ts
+++ b/api/src/services/evaluation.service.ts
@@ -94,9 +94,7 @@ export class EvaluationService {
       '-m',
       [
         'eval.run_generated_agent_evaluation',
-        evaluationCasePath,
-        agentTracePath,
-        evaluationResultsPath,
+        workflowDir,
       ],
       outputCallback,
       env,

--- a/api/src/services/process.service.ts
+++ b/api/src/services/process.service.ts
@@ -369,21 +369,14 @@ export class ProcessService {
       const fullWorkflowPath = getWorkflowPath(workflowPath)
 
       // Build the specific file paths that the Python script expects
-      const evaluationCaseFile = `${fullWorkflowPath}/evaluation_case.json`
-      const agentTraceFile = `${fullWorkflowPath}/agent_eval_trace.json`
-      const resultsFile = `${fullWorkflowPath}/evaluation_results.json`
+      const workflowDir = `${fullWorkflowPath}`
 
       this.agentFactoryProcess = spawn(
         config.pythonExecutable,
         [
           '-m',
           'eval.run_generated_agent_evaluation',
-          '--evaluation_case_json_file',
-          evaluationCaseFile,
-          '--agent_trace_json_file',
-          agentTraceFile,
-          '--save_evaluation_results_path',
-          resultsFile,
+          workflowDir,
         ],
         {
           stdio: 'pipe',

--- a/eval/generate_evaluation_case.py
+++ b/eval/generate_evaluation_case.py
@@ -8,7 +8,7 @@ from any_agent.config import MCPStdio
 from any_agent.tools import search_tavily, visit_webpage
 from pydantic import BaseModel, Field
 
-from eval.instructions import INSTRUCTIONS
+from eval.instructions import get_instructions
 
 dotenv.load_dotenv()
 
@@ -47,7 +47,7 @@ def main(generated_workflow_dir: str = "generated_workflows/latest"):
         framework,
         AgentConfig(
             model_id="gpt-4.1",
-            instructions=INSTRUCTIONS,
+            instructions=get_instructions(generated_workflow_dir),
             tools=[
                 visit_webpage,
                 search_tavily,
@@ -76,7 +76,7 @@ def main(generated_workflow_dir: str = "generated_workflows/latest"):
     )
 
     run_instructions = """
-    Read the generated_workflows/latest/agent.py script and generate a JSON evaluation case for it.
+    Read the {generated_workflow_dir}/agent.py script and generate a JSON evaluation case for it.
     The criteria generated must:
     - be specific, measurable, and independent.
     - should not be vague or open-ended or generic.
@@ -84,7 +84,7 @@ def main(generated_workflow_dir: str = "generated_workflows/latest"):
     - be solely based on the agent's INSTRUCTIONS, tools in the agent configuration (including MCPs) and output_type JSON structured output.
     You may ignore the framework name and model_id in the agent configuration.
     """  # noqa: E501
-    agent_trace = agent.run(run_instructions, max_turns=30)
+    agent_trace = agent.run(run_instructions.format(generated_workflow_dir=generated_workflow_dir), max_turns=30)
 
     cost_info = agent_trace.cost
     evaluation_case_generation_costs = {

--- a/eval/instructions.py
+++ b/eval/instructions.py
@@ -113,8 +113,9 @@ Always use openai/gpt-4.1 as the llm_judge.
 """  # noqa: E501
 
 INSTRUCTIONS_TEMPLATE = """
-1. List files in the generated_workflows/latest directory.
-2. Check the file generated_workflows/latest/agent.py.
+The generated_workflow_dir is {{ generated_workflow_dir }}.
+1. List files in the {{ generated_workflow_dir }} directory.
+2. Check the file {{ generated_workflow_dir }}/agent.py.
 3. Generate a comprehensive JSON evaluation file for the given agent.py script.
 
 Analyze the agent's task, tools, and expected workflow to create thorough evaluation criteria.
@@ -134,10 +135,13 @@ You may access to the following webpages using `visit_webpage` tool:
 
 """  # noqa: E501
 
-# Render the template with the WEBPAGE_DESCRIPTIONS dictionary
-template = Template(INSTRUCTIONS_TEMPLATE)
-INSTRUCTIONS = template.render(
-    webpage_descriptions=WEBPAGE_DESCRIPTIONS,
-    evaluation_categories=EVALUATION_CATEGORIES,
-    agent_script_and_json_example=AGENT_SCRIPT_AND_JSON_EXAMPLE,
-)
+
+def get_instructions(generated_workflow_dir: str) -> str:
+    """Get evaluation instructions with the generated_workflow_dir properly set."""
+    template = Template(INSTRUCTIONS_TEMPLATE)
+    return template.render(
+        generated_workflow_dir=generated_workflow_dir,
+        webpage_descriptions=WEBPAGE_DESCRIPTIONS,
+        evaluation_categories=EVALUATION_CATEGORIES,
+        agent_script_and_json_example=AGENT_SCRIPT_AND_JSON_EXAMPLE,
+    )

--- a/eval/run_generated_agent_evaluation.py
+++ b/eval/run_generated_agent_evaluation.py
@@ -13,22 +13,34 @@ from eval.generate_evaluation_case import JSONEvaluationCase
 
 
 async def run_evaluation(
-    evaluation_case_json_file: str = "generated_workflows/latest/evaluation_case.json",
-    agent_trace_json_file: str = "generated_workflows/latest/agent_eval_trace.json",
-    save_evaluation_results_path: str = "generated_workflows/latest/evaluation_results.json",
+    generated_workflow_dir: str = "generated_workflows/latest",
+    evaluation_case_json_file: str | None = None,
+    agent_trace_json_file: str | None = None,
+    save_evaluation_results_path: str | None = None,
 ):
     """Runs the evaluation process based on an evaluation case JSON file and an agent trace JSON file.
 
     Args:
-        evaluation_case_json_file (str): Path to the evaluation case JSON file.
-        Defaults to "generated_workflows/evaluation_case.json".
+        generated_workflow_dir (str): The directory of the generated workflow.
+        Defaults to "generated_workflows/latest".
 
-        agent_trace_json_file (str): Path to the agent trace JSON file.
-        Defaults to "generated_workflows/agent_eval_trace.json".
+        evaluation_case_json_file (str, optional): Path to the evaluation case JSON file.
+        If None, will use generated_workflow_dir/evaluation_case.json.
 
-        save_evaluation_results_path (str): Path to save the evaluation results JSON file.
-        Defaults to "generated_workflows/evaluation_results.json".
+        agent_trace_json_file (str, optional): Path to the agent trace JSON file.
+        If None, will use generated_workflow_dir/agent_eval_trace.json.
+
+        save_evaluation_results_path (str, optional): Path to save the evaluation results JSON file.
+        If None, will use generated_workflow_dir/evaluation_results.json.
     """
+    # Set default paths based on generated_workflow_dir if not provided
+    if evaluation_case_json_file is None:
+        evaluation_case_json_file = f"{generated_workflow_dir}/evaluation_case.json"
+    if agent_trace_json_file is None:
+        agent_trace_json_file = f"{generated_workflow_dir}/agent_eval_trace.json"
+    if save_evaluation_results_path is None:
+        save_evaluation_results_path = f"{generated_workflow_dir}/evaluation_results.json"
+
     try:
         # Load evaluation case from the specified JSON file
         with Path(evaluation_case_json_file).open(encoding="utf-8") as f:

--- a/test/README.md
+++ b/test/README.md
@@ -144,8 +144,13 @@ test_results/
 └── ...
 
 generated_workflows/
-  ├── 2025-06-09_14:25:59_d34db33f/
-  └── ...
+├── 2025-06-09_14:25:59_d34db33f/                   # Most recent generated agent
+│   ├── agent.py
+│   ├── README.md
+│   └── requirements.txt\
+└── ...
+
+
 ```
 
 ## Visual Results Analysis

--- a/test/README.md
+++ b/test/README.md
@@ -144,13 +144,8 @@ test_results/
 └── ...
 
 generated_workflows/
-├── latest/                   # Most recent generated agent
-│   ├── agent.py
-│   ├── README.md
-│   └── requirements.txt
-└── archive/                  # Previously generated agents
-    ├── 2025-06-09_14:25:59_d34db33f/
-    └── ...
+  ├── 2025-06-09_14:25:59_d34db33f/
+  └── ...
 ```
 
 ## Visual Results Analysis

--- a/tests/generated_agent_evaluation/test_run_agent_evaluation.py
+++ b/tests/generated_agent_evaluation/test_run_agent_evaluation.py
@@ -18,9 +18,7 @@ def test_evaluation_runs_with_valid_inputs(tmpdir, sample_evaluation_json_file, 
         # The run_evaluation function is async, so we need to await it
         asyncio.run(
             run_evaluation(
-                evaluation_case_json_file=str(evaluation_case_path),
-                agent_trace_json_file=str(agent_trace_path),
-                save_evaluation_results_path=str(results_path),
+                generated_workflow_dir=str(tmpdir),
             )
         )
 


### PR DESCRIPTION
## 📝 What's changing

- update eval scripts and agent instructions to use the correct agent directory instead of `latest/`
- updates `run_generated_agent_evaluation.py` to require only the agent directory as a param instead of explicit paths to `evaluation_case.json`, `agent_eval_trace.json` and `evaluation_results.json`
- Update the related NodeJS api endpoint to pass only the agent directory instead of explicit paths to the trace/case/results files


---

## 📚 How to test it

Steps to test the changes:

1. `python eval/generate_evaluation_case.py generated_workflows/2025-07-03_16:33:14_8fc54b0e`
2. `python eval/run_generated_agent_evaluation.py generated_workflows/2025-07-03_16:33:14_8fc54b0e`
3. prompt / trace / logs from both command should no longer reference `latest/` directory, but the correct passed in directory instead

---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [x] Added some tests for any new functionality
- [x] Tested the changes in a working environment to ensure they work as expected
- [x] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [insert-link-here]
  >Note: The can be done from [Actions tab in GitHub UI](https://github.com/mozilla-ai/agent-factory/actions/workflows/tests.yaml) -> Select the pinned `Tests` workflow from the left sidebar -> Select `your-branch-name` -> `Run workflow`

---

## 📸 Screenshots (if applicable)

Please add any relevant screenshots to show the changes (e.g. agent performance in comparison to `main` branch).
