### PR TITLE
Change mcpm registry URL

### DIFF
--- a/src/agent/factory_tools.py
+++ b/src/agent/factory_tools.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from mcpm.utils.repository import RepositoryManager
 
-DEFAULT_REGISTRY_URL = "https://getmcp.io/api/servers.json"
+DEFAULT_REGISTRY_URL = "https://mcpm.sh/api/servers.json"
 
 KEYS_TO_DROP = ("display_name", "repository", "homepage", "author", "categories", "tags", "docker_url", "examples")
 

--- a/tests/generated_artifacts/test_generated_agents.py
+++ b/tests/generated_artifacts/test_generated_agents.py
@@ -41,9 +41,12 @@ def test_specific_tool_used(generated_agent_code: str, request: pytest.FixtureRe
             "MCP server(s) required for url-to-podcast workflow"
         )
         # Necessary ElevenLabs MCP tools used
-        assert "generate_audio_" in generated_agent_code
+        assert "text_to_speech" in generated_agent_code
         # Non-essential tools NOT used
-        assert all(term not in generated_agent_code for term in ("delete_job", "get_voiceover_history"))
+        assert all(
+            term not in generated_agent_code
+            for term in ("text_to_sound_effects", "create_agent", "speech_to_speech", "speech_to_text")
+        )
 
     elif "scoring-blueprints-submission":
         # Either visit_webpage or extract_text_from_url should be used, using both is also fine


### PR DESCRIPTION
## 📝 What's changing

https://getmcp.io/api/servers.json does not seem to be updated (for example: ElevenLabs official MCP is not present there but present in https://mcpm.sh/api/servers.json)

---

## 📚 How to test it

Steps to test the changes:

1. Run agent-factory CLI with elevenlabs use case

---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [x] Added some tests for any new functionality - Updated tests
- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [insert-link-here]
  >Note: The can be done from [Actions tab in GitHub UI](https://github.com/mozilla-ai/agent-factory/actions/workflows/tests.yaml) -> Select the pinned `Tests` workflow from the left sidebar -> Select `your-branch-name` -> `Run workflow`

---

## 📸 Screenshots (if applicable)

Please add any relevant screenshots to show the changes (e.g. agent performance in comparison to `main` branch).
