### PR TITLE
A2a client refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+# Makefile for Agent Factory
+
+# Configuration
+DOCKER_IMAGE = agent-factory
+DOCKER_CONTAINER = agent-factory-a2a
+DOCKER_TAG = latest
+A2A_SERVER_HOST = localhost
+A2A_SERVER_PORT = 8080
+
+# Default target
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@echo "  build           - Build the Docker image for Agent Factory A2A server"
+	@echo "  run             - Run the A2A server in Docker"
+	@echo "  stop            - Stop the running container"
+	@echo "  clean           - Remove Docker containers and images"
+
+# Build the Docker image
+.PHONY: build
+build:
+	docker build --build-arg APP_VERSION=$(shell git describe --tags --dirty 2>/dev/null || echo "dev") -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
+
+# Run the server in Docker
+.PHONY: run
+run: build
+	@if [ ! -f .env ]; then \
+		echo "Error: .env file not found. Please create one with your API keys."; \
+		exit 1; \
+	fi
+	docker run --rm -d \
+		--name $(DOCKER_CONTAINER) \
+		-p $(A2A_SERVER_PORT):8080 \
+		--env-file .env \
+		$(DOCKER_IMAGE):$(DOCKER_TAG)
+	@echo "Server running at http://$(A2A_SERVER_HOST):$(A2A_SERVER_PORT)"
+
+# Stop the running container
+.PHONY: stop
+stop:
+	@docker stop $(DOCKER_CONTAINER) 2>/dev/null || true
+
+# Clean up Docker resources
+.PHONY: clean
+clean: stop
+	@docker rmi $(DOCKER_IMAGE):$(DOCKER_TAG) 2>/dev/null || true
+
+# Default target
+.DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -85,34 +85,27 @@ In addition to `host` and `port`, you can also pass the following arguments:
 > Visit the any-agent [documentation](https://mozilla-ai.github.io/any-agent/) for more details on the supported
 > frameworks.
 
-#### Using Docker
+#### Using Makefile
 
-To run the server in a Docker container, follow these steps.
+The Makefile enables you to run the server using Docker.
 
-1.  **Build the Docker image:**
+**Run the server** (this will also build the image if needed):
+   ```bash
+   make run
+   ```
+   The server will be available at `http://localhost:8080`.
 
-    From the root of the project, run the following commands to build the Docker image:
+> [!NOTE]
+> Before running the server, make sure to create a `.env` file in the project root with your required environment variables, including your `OPENAI_API_KEY`:
+> ```
+> OPENAI_API_KEY=sk-...
+> ```
 
-    ```bash
-    export VER=$(git describe --tags --dirty)
-    docker build --build-arg APP_VERSION=$VER  -t agent-factory .
-    ```
-
-2.  **Run the Docker container:**
-
-    Create a `.env` file in the project root with your `OPENAI_API_KEY`:
-
-    ```
-    OPENAI_API_KEY=sk-...
-    ```
-
-    Then, run the container, passing the `.env` file:
-
-    ```bash
-    docker run --rm -p 8080:8080 --env-file .env agent-factory
-    ```
-
-    The server will be available at `http://localhost:8080`.
+> [!NOTE]
+> After generating your agents using the `agent-factory` command (described below), don't forget to stop the server using:
+> ```bash
+> make stop
+> ```
 
 ### Generate an Agentic Workflow
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires = ["setuptools>=48", "setuptools_scm[toml]>=6.3.1"]
 build-backend = "setuptools.build_meta"
 
 [project.scripts]
-agent-factory = "agent_factory.test_client:main"
+agent-factory = "agent_factory.agent_generation:main"
 
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*"]

--- a/src/agent_factory/agent_generation.py
+++ b/src/agent_factory/agent_generation.py
@@ -17,7 +17,7 @@ PUBLIC_AGENT_CARD_PATH = "/.well-known/agent.json"
 EXTENDED_AGENT_CARD_PATH = "/agent/authenticatedExtendedCard"
 
 
-async def generate(
+async def generate_target_agent(
     message: str,
     output_dir: Path | None = None,
     host: str = "localhost",
@@ -52,7 +52,7 @@ async def generate(
 
 
 def main():
-    fire.Fire(generate)
+    fire.Fire(generate_target_agent)
 
 
 if __name__ == "__main__":

--- a/src/agent_factory/test_client.py
+++ b/src/agent_factory/test_client.py
@@ -12,61 +12,10 @@ from a2a.types import (
     SendMessageRequest,
 )
 
-from agent_factory.instructions import AGENT_CODE_TEMPLATE, AGENT_CODE_TEMPLATE_RUN
-from agent_factory.utils import clean_python_code_with_autoflake, logger, setup_output_directory
+from agent_factory.utils import logger, save_agent_outputs, setup_output_directory
 
 PUBLIC_AGENT_CARD_PATH = "/.well-known/agent.json"
 EXTENDED_AGENT_CARD_PATH = "/agent/authenticatedExtendedCard"
-
-
-def save_agent_outputs(result: dict[str, str], output_dir: Path) -> None:
-    """Save the agent outputs to files.
-
-    This function takes a dictionary containing the agent outputs and saves them to
-    an output directory. It creates three different files in the output directory:
-        - agent.py: Contains the agent code.
-        - README.md: Contains the run instructions in Markdown format.
-        - requirements.txt: Contains the dependencies line by line.
-
-    Args:
-        result: A dictionary containing the agent outputs. It should include the following keys:
-            - agent_code: The Python code for the agent.
-            - readme: The instructions for running the agent in Markdown format.
-            - dependencies: A string containing the dependencies required by the agent, one per line.
-
-    Raises:
-        Exception: If there is an error while writing the files to the output directory.
-    """
-    try:
-        agent_path = output_dir / "agent.py"
-        readme_path = output_dir / "README.md"
-        requirements_path = output_dir / "requirements.txt"
-        tools_dir_path = output_dir / "tools"
-        tools_dir_path.mkdir(exist_ok=True)
-        agent_code = f"{AGENT_CODE_TEMPLATE.format(**result)} \n{AGENT_CODE_TEMPLATE_RUN.format(**result)}"
-
-        clean_agent_code = clean_python_code_with_autoflake(agent_code)
-
-        with agent_path.open("w", encoding="utf-8") as f:
-            f.write(clean_agent_code)
-
-        with readme_path.open("w", encoding="utf-8") as f:
-            f.write(result["readme"])
-
-        with requirements_path.open("w", encoding="utf-8") as f:
-            f.write(result["dependencies"])
-
-        tools_dir = Path("src/agent_factory/tools")
-        for tool_file in tools_dir.iterdir():
-            if tool_file.is_file() and (tool_file.stem in agent_code or tool_file.name == "__init__.py"):
-                tool_destination = tools_dir_path / tool_file.name
-                # Copy the tool file to the output directory
-                tool_destination.write_text(tool_file.read_text(encoding="utf-8"), encoding="utf-8")
-
-        logger.info(f"Agent files saved to {output_dir}")
-
-    except Exception as e:
-        logger.warning(f"Warning: Failed to parse and save agent outputs: {str(e)}")
 
 
 async def generate(

--- a/src/agent_factory/test_client.py
+++ b/src/agent_factory/test_client.py
@@ -1,18 +1,17 @@
-import json
 from pathlib import Path
-from typing import Any
-from uuid import uuid4
 
 import fire
-import httpx
 from a2a.client import A2ACardResolver, A2AClient
-from a2a.types import (
-    AgentCard,
-    MessageSendParams,
-    SendMessageRequest,
-)
 
-from agent_factory.utils import logger, save_agent_outputs, setup_output_directory
+from agent_factory.utils import (
+    create_a2a_http_client,
+    create_message_request,
+    get_a2a_agent_card,
+    process_a2a_agent_response,
+    save_agent_outputs,
+    setup_output_directory,
+)
+from agent_factory.utils.logging import logger
 
 PUBLIC_AGENT_CARD_PATH = "/.well-known/agent.json"
 EXTENDED_AGENT_CARD_PATH = "/agent/authenticatedExtendedCard"
@@ -28,43 +27,26 @@ async def generate(
     """Main entry point for the A2A client application.
 
     Args:
-        message (str): The message to send to the agent.
-        host (str): The host address for the agent server (default: "localhost").
-        port (int): The port for the agent server (default: 8080).
-        timeout (str): The timeout for the request in seconds (default: 600).
+        message: The message to send to the agent.
+        output_dir: Directory to save agent outputs. If None, a default is used.
+        host: The host address for the agent server (default: "localhost").
+        port: The port for the agent server (default: 8080).
+        timeout: The timeout for the request in seconds (default: 600).
     """
-    base_url = f"http://{host}:{port}"
+    http_client, base_url = await create_a2a_http_client(host, port)
+    async with http_client as client:
+        resolver = A2ACardResolver(httpx_client=client, base_url=base_url)
+        agent_card = await get_a2a_agent_card(resolver)
 
-    async with httpx.AsyncClient() as httpx_client:
-        resolver = A2ACardResolver(
-            httpx_client=httpx_client,
-            base_url=base_url,
-        )
-
-        try:
-            agent_card: AgentCard = await resolver.get_agent_card()
-        except Exception as e:
-            logger.error(f"Critical error fetching public agent card: {e}", exc_info=True)
-            raise RuntimeError("Failed to fetch the public agent card. Cannot continue.") from e
-
-        client = A2AClient(httpx_client=httpx_client, agent_card=agent_card)
+        # Initialize client and send message
+        client = A2AClient(httpx_client=client, agent_card=agent_card)
         logger.info("A2AClient initialized.")
 
-        send_message_payload: dict[str, Any] = {
-            "message": {
-                "role": "user",
-                "parts": [{"kind": "text", "text": message}],
-                "messageId": uuid4().hex,
-            },
-        }
-        request = SendMessageRequest(id=str(uuid4()), params=MessageSendParams(**send_message_payload))
-
+        request = create_message_request(message)
         response = await client.send_message(request, http_kwargs={"timeout": timeout})
-        logger.info(response.model_dump(mode="json", exclude_none=True))
 
-        result = json.loads(response.root.result.status.message.parts[0].root.text)
-        logger.info(f"Received response from agent: {result}")
-
+        # Process response
+        result = process_a2a_agent_response(response)
         output_dir = setup_output_directory(output_dir)
         save_agent_outputs(result, output_dir)
 

--- a/src/agent_factory/utils/__init__.py
+++ b/src/agent_factory/utils/__init__.py
@@ -1,10 +1,13 @@
 from .artifact_validation import clean_python_code_with_autoflake
+from .client_utils import create_a2a_http_client, create_message_request, get_a2a_agent_card, process_a2a_agent_response
 from .io_utils import save_agent_outputs, setup_output_directory
-from .logging import logger
 
 __all__ = [
     "clean_python_code_with_autoflake",
     "setup_output_directory",
-    "logger",
     "save_agent_outputs",
+    "create_a2a_http_client",
+    "get_a2a_agent_card",
+    "create_message_request",
+    "process_a2a_agent_response",
 ]

--- a/src/agent_factory/utils/__init__.py
+++ b/src/agent_factory/utils/__init__.py
@@ -1,9 +1,10 @@
 from .artifact_validation import clean_python_code_with_autoflake
-from .io_utils import setup_output_directory
+from .io_utils import save_agent_outputs, setup_output_directory
 from .logging import logger
 
 __all__ = [
     "clean_python_code_with_autoflake",
     "setup_output_directory",
     "logger",
+    "save_agent_outputs",
 ]

--- a/src/agent_factory/utils/client_utils.py
+++ b/src/agent_factory/utils/client_utils.py
@@ -1,0 +1,51 @@
+"""Utility functions for the A2A client."""
+
+import json
+from typing import Any
+from uuid import uuid4
+
+import httpx
+from a2a.client import A2ACardResolver
+from a2a.types import AgentCard, MessageSendParams, SendMessageRequest
+
+from agent_factory.utils.logging import logger
+
+
+async def create_a2a_http_client(host: str, port: int) -> tuple[httpx.AsyncClient, str]:
+    """Create and return an HTTP client with base URL.
+
+    Args:
+        host: The host address for the agent server.
+        port: The port for the agent server.
+    """
+    base_url = f"http://{host}:{port}"
+    return httpx.AsyncClient(), base_url
+
+
+async def get_a2a_agent_card(resolver: A2ACardResolver) -> AgentCard:
+    """Fetch the agent card from the resolver."""
+    try:
+        return await resolver.get_agent_card()
+    except Exception as e:
+        logger.error(f"Critical error fetching public agent card: {e}", exc_info=True)
+        raise RuntimeError("Failed to fetch the public agent card. Cannot continue.") from e
+
+
+def create_message_request(message: str) -> SendMessageRequest:
+    """Create a message request to send to the agent."""
+    send_message_payload = {
+        "message": {
+            "role": "user",
+            "parts": [{"kind": "text", "text": message}],
+            "messageId": uuid4().hex,
+        },
+    }
+    return SendMessageRequest(id=str(uuid4()), params=MessageSendParams(**send_message_payload))
+
+
+def process_a2a_agent_response(response: Any) -> dict:
+    """Process the response from the agent."""
+    logger.info(response.model_dump(mode="json", exclude_none=True))
+    result = json.loads(response.root.result.status.message.parts[0].root.text)
+    logger.info(f"Received response from agent: {result}")
+    return result

--- a/src/agent_factory/utils/io_utils.py
+++ b/src/agent_factory/utils/io_utils.py
@@ -2,6 +2,10 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 
+from agent_factory.instructions import AGENT_CODE_TEMPLATE, AGENT_CODE_TEMPLATE_RUN
+from agent_factory.utils import clean_python_code_with_autoflake
+from agent_factory.utils.logging import logger
+
 
 def setup_output_directory(output_dir: Path | None = None) -> Path:
     if output_dir is None:
@@ -15,3 +19,53 @@ def setup_output_directory(output_dir: Path | None = None) -> Path:
 
     output_dir.mkdir(parents=True, exist_ok=True)
     return output_dir
+
+
+def save_agent_outputs(result: dict[str, str], output_dir: Path) -> None:
+    """Save the agent outputs to files.
+
+    This function takes a dictionary containing the agent outputs and saves them to
+    an output directory. It creates three different files in the output directory:
+        - agent.py: Contains the agent code.
+        - README.md: Contains the run instructions in Markdown format.
+        - requirements.txt: Contains the dependencies line by line.
+
+    Args:
+        result: A dictionary containing the agent outputs. It should include the following keys:
+            - agent_code: The Python code for the agent.
+            - readme: The instructions for running the agent in Markdown format.
+            - dependencies: A string containing the dependencies required by the agent, one per line.
+
+    Raises:
+        Exception: If there is an error while writing the files to the output directory.
+    """
+    try:
+        agent_path = output_dir / "agent.py"
+        readme_path = output_dir / "README.md"
+        requirements_path = output_dir / "requirements.txt"
+        tools_dir_path = output_dir / "tools"
+        tools_dir_path.mkdir(exist_ok=True)
+        agent_code = f"{AGENT_CODE_TEMPLATE.format(**result)} \n{AGENT_CODE_TEMPLATE_RUN.format(**result)}"
+
+        clean_agent_code = clean_python_code_with_autoflake(agent_code)
+
+        with agent_path.open("w", encoding="utf-8") as f:
+            f.write(clean_agent_code)
+
+        with readme_path.open("w", encoding="utf-8") as f:
+            f.write(result["readme"])
+
+        with requirements_path.open("w", encoding="utf-8") as f:
+            f.write(result["dependencies"])
+
+        tools_dir = Path("src/agent_factory/tools")
+        for tool_file in tools_dir.iterdir():
+            if tool_file.is_file() and (tool_file.stem in agent_code or tool_file.name == "__init__.py"):
+                tool_destination = tools_dir_path / tool_file.name
+                # Copy the tool file to the output directory
+                tool_destination.write_text(tool_file.read_text(encoding="utf-8"), encoding="utf-8")
+
+        logger.info(f"Agent files saved to {output_dir}")
+
+    except Exception as e:
+        logger.warning(f"Warning: Failed to parse and save agent outputs: {str(e)}")


### PR DESCRIPTION
## 📝 What's changing

This PR breaks up agent_factory/test_client.py (renamed to agent_generation.py) into smaller functions that can be individually tested.

We also introduce a `Makefile` to make running a2a server via docker easier - This will be used later to include different test groups later (test-unit, test-integration, test-evaluation, etc. which could make it easier for devs to run tests against their changes - similar to how we had it in Lumigator) 

---

## 📚 How to test it

Steps to test the changes:

1. `make run`
2. Check A2A is running on http://127.0.0.1:8080/.well-known/agent.json 
3. `uv run agent-factory "Curate best sushi restaurants in the city given by the user"`
4. Check results are saved in `generated_workflows/`

---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [ ] Added some tests for any new functionality
- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [insert-link-here]
  >Note: The can be done from [Actions tab in GitHub UI](https://github.com/mozilla-ai/agent-factory/actions/workflows/tests.yaml) -> Select the pinned `Tests` workflow from the left sidebar -> Select `your-branch-name` -> `Run workflow`

---

## 📸 Screenshots (if applicable)

Please add any relevant screenshots to show the changes (e.g. agent performance in comparison to `main` branch).
