### PR TITLE
docs: initial content, automated doc build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,72 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'src/**'
+      - 'mkdocs.yml'
+      - 'pyproject.toml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'src/**'
+      - 'mkdocs.yml'
+      - 'pyproject.toml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build docs
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: latest
+
+      - name: Install dependencies
+        run: |
+          uv sync --group docs
+
+      - name: Build documentation
+        run: |
+          uv run mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  # Deploy docs
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/mcp-tests.yaml
+++ b/.github/workflows/mcp-tests.yaml
@@ -52,7 +52,7 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add docs/mcp-servers.md
+          git add docs/user-guide/mcp-servers.md
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help prepare build run run-detached stop clean wait-for-server test-single-turn-generation test-single-turn-generation-local test-single-turn-generation-e2e test-unit test-generated-artifacts test-mcps update-docs
+.PHONY: help prepare build run run-detached stop clean wait-for-server test-single-turn-generation test-single-turn-generation-local test-single-turn-generation-e2e test-unit test-generated-artifacts test-mcps update-docs docs-serve docs-build
 
 # ====================================================================================
 # Configuration
@@ -187,7 +187,22 @@ test-mcps: ## Run MCP server tests
 	@echo "Running MCP server tests..."
 	uv run python -m docs.scripts.test_mcp_servers
 
-update-docs: test-mcps ## Update MCP documentation
+update-mcps: test-mcps ## Update only the MCP doc with the results of the tests
 	@echo "Generating MCP documentation..."
 	uv run python -m docs.scripts.generate_mcp_table
-	@echo "Documentation updated successfully!"
+	@echo "MCP documentation updated successfully!"
+
+# ====================================================================================
+# Documentation
+# ====================================================================================
+
+docs-serve: ## Serve documentation locally
+	@echo "Starting MkDocs development server..."
+	@uv sync --quiet --group docs
+	@uv run mkdocs serve
+
+docs-build:
+	@echo "Building documentation..."
+	@uv sync --quiet --group docs
+	@uv run mkdocs build
+	@echo "Documentation built successfully!"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,120 @@
+# Installation
+
+## Prerequisites
+
+- [curl](https://curl.se/)
+- [jq](https://jqlang.org/)
+- [Python 3.13+](https://www.python.org/downloads/)
+- [uv](https://github.com/astral-sh/uv)
+- [Docker](https://www.docker.com/products/docker-desktop/) (for containerized deployment)
+- [mcpd](https://github.com/mozilla-ai/mcpd/releases) added to `PATH`, e.g. `/usr/local/bin` (for local deployment)
+
+## Installation
+
+1. Clone the repository and navigate to the agent's source directory:
+   ```bash
+   git clone https://github.com/mozilla-ai/agent-factory.git && cd agent-factory
+   ```
+
+2. Install the dependencies using `uv`:
+   ```bash
+   uv sync --dev
+   ```
+
+3. Activate the virtual environment:
+   ```bash
+   source .venv/bin/activate
+   ```
+
+4. Install pre-commit hooks:
+   ```bash
+   pre-commit install
+   ```
+
+5. Create a `.env` file in the project root and add your OpenAI API key and Tavily API key (required). You can get a free Tavily API key by signing up [here](https://www.tavily.com/).
+   ```bash
+   OPENAI_API_KEY=sk-...
+   TAVILY_API_KEY=tvly_...
+   ```
+
+## Run the Server
+
+To run the server locally, execute the following command from the `src/agent_factory` directory:
+
+```bash
+cd src/agent_factory && uv run . --host 0.0.0.0 --port 8080
+```
+
+The server will be available at `http://localhost:8080/.well-known/agent.json`.
+
+In addition to `host` and `port`, you can also pass the following arguments:
+
+-  `chat` vs `nochat`: `chat` mode enables multi-turn conversations, while `nochat` mode is for one-shot tasks (default:
+   `chat`).
+-  `framework`: The Agent framework to use (default: `openai`).
+-  `model`: The model ID to use (default: `o3`).
+-  `log_level`: The logging level (default: `info`).
+
+> [!NOTE]
+> Visit the any-agent [documentation](https://mozilla-ai.github.io/any-agent/) for more details on the supported
+> frameworks.
+
+## Generate an Agentic Workflow
+
+> [!IMPORTANT]
+> Always run the server in non-chat mode (`--nochat`) when generating agents using the `agent-factory` command.
+> For multi-turn conversations, see the section on [Multi-Turn Conversations](#multi-turn-conversations).
+
+Once the server is running, run the `agent-factory` CLI tool with your desired workflow prompt:
+
+```bash
+uv run agent-factory "Summarize text content from a given webpage URL"
+```
+
+The client will send the message to the server, print the response, and save the generated agent's files (`agent.py`,
+`README.md`, `requirements.txt`, and `agent_parameters.json`) into a new directory inside the `generated_workflows` directory.
+
+## Run the Generated Workflow
+
+To run the generated agent, navigate to the directory where the agent was saved and execute:
+
+```bash
+uv run --with-requirements requirements.txt --python 3.13 python agent.py --arg1 "value1"
+```
+
+Replace `--arg1 "value1"` with the actual arguments required by the generated agent. The command will execute the agent
+and save the agent trace as `agent_trace.json` in the agent's directory.
+
+> [!NOTE]
+> You can append the `--help` flag to the command to see the available options for the generated agent.
+
+> [!NOTE]
+> The agent-factory has been instructed to set the max_turns (the max number of steps that the generated agent can take
+> to complete the workflow) to 20. Please inspect the generated agent code and override this value if needed (if you see
+> the generated agent run failing due to AgentRunError caused by MaxTurnsExceeded).
+
+## Evaluate the Generated Agent
+
+Run the evaluation case generator agent with your desired evaluation case prompt:
+
+```bash
+uv run -m eval.generate_evaluation_case path/to/the/generated/agent
+```
+
+This will generate a JSON file in the generated agent's directory with evaluation criteria. Next, evaluate the agent's
+execution trace against the generated evaluation case:
+
+```bash
+uv run -m eval.run_generated_agent_evaluation path/to/the/generated/agent
+```
+
+This command will display the evaluation criteria and show how the agent performed on each.
+
+## Multi-Turn Conversations
+
+Agent Factory supports multi-turn conversations. You can run the Chainlit application to interact with the Agent server
+in a conversational manner:
+
+```bash
+uv run chainlit run src/agent_factory/chainlit.py
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+# Agent Factory
+
+> **A factory for automatically creating agentic workflows.**
+
+Agent Factory is a powerful tool for generating AI agents and workflows using the Model Context Protocol (MCP). It transforms natural language descriptions into executable Python code for agentic workflows, powered by the any-agent library.
+
+## Installation
+
+Refer to the [Installation](getting-started/installation.md) for instructions on setup and usage.
+
+## MCP Servers
+
+Available MCP servers and tools are documented in [MCP Servers](user-guide/mcp-servers.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 > **A factory for automatically creating agentic workflows.**
 
-Agent Factory is a powerful tool for generating AI agents and workflows using the Model Context Protocol (MCP). It transforms natural language descriptions into executable Python code for agentic workflows, powered by the any-agent library.
+Agent Factory is a powerful tool for generating AI agents and workflows using the Model Context Protocol (MCP). It transforms natural language descriptions into executable Python code for agentic workflows, powered by the [any-agent](https://mozilla-ai.github.io/any-agent/) library.
 
 ## Installation
 

--- a/docs/scripts/generate_mcp_table.py
+++ b/docs/scripts/generate_mcp_table.py
@@ -93,17 +93,20 @@ def reconstruct_file(intro: str, dynamic_content: str, outro: str) -> str:
 
 
 def update_markdown_file(
-    markdown_file: str = "docs/mcp-servers.md", results_file: str = ".cache/mcp-test-results.json"
+    markdown_file: str = "docs/user-guide/mcp-servers.md",
+    template_file: str = "docs/user-guide/mcp-servers.template.md",
+    results_file: str = ".cache/mcp-test-results.json",
 ):
     """Update the markdown file with new test results."""
     test_data = load_test_results(results_file)
 
-    with Path(markdown_file).open("r") as f:
+    # Read from template file instead of existing markdown file
+    with Path(template_file).open("r") as f:
         content = f.read()
 
     try:
         # We now have a static section before the marker and another after the end marker - we reuse all
-        # this from the existing file. There is only one part that needs to be generated and placed between
+        # this from the template file. There is only one part that needs to be generated and placed between
         # the two markers.
         intro, outro = extract_static_file_sections(content)
     except ValueError as e:

--- a/docs/scripts/generate_mcp_table.py
+++ b/docs/scripts/generate_mcp_table.py
@@ -94,7 +94,7 @@ def reconstruct_file(intro: str, dynamic_content: str, outro: str) -> str:
 
 def update_markdown_file(
     markdown_file: str = "docs/user-guide/mcp-servers.md",
-    template_file: str = "docs/user-guide/mcp-servers.template.md",
+    template_file: str = "docs/user-guide/mcp-servers-template.md",
     results_file: str = ".cache/mcp-test-results.json",
 ):
     """Update the markdown file with new test results."""

--- a/docs/user-guide/mcp-servers-template.md
+++ b/docs/user-guide/mcp-servers-template.md
@@ -1,0 +1,98 @@
+# MCP Servers
+
+This page lists the available Model Context Protocol (MCP) servers that can be used with Agent Factory. These servers extend the capabilities of your AI agents by providing access to various services, APIs, and data sources.
+
+> **⚠️ Note: This page is automatically generated, from a template and test results, and should not be manually edited.**
+> To add a new MCP server, edit the `docs/mcp-servers.json` file. Tests will be run automatically and results will be published in the table below.
+
+
+## Server Status Legend
+
+- ✅ **Confirmed**: Server has been tested and confirmed working
+- ⏭️ **Skipped**: Server was skipped during testing (Docker-based servers)
+- ❌ **Failed**: Server failed the latest test
+
+
+## Quick Reference Table
+
+The following table provides a quick overview of tested MCP servers. For detailed information about each server, see the sections below.
+
+
+<!-- MCP_SERVERS_TABLE_START -->
+<!-- DYNAMIC_CONTENT_WILL_BE_INSERTED_HERE -->
+<!-- MCP_SERVERS_TABLE_END -->
+
+
+## Installation & Setup
+
+### Prerequisites
+
+Before installing MCP servers, ensure you have:
+
+1. **Node.js** (for npx installations)
+2. **uv** (for uvx installations)
+3. **Proper API keys** for the services you want to use
+
+Please note that **Docker**-based MCP servers are not supported as this time.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Permission Errors**: Ensure proper permissions for file system access
+2. **API Key Issues**: Verify API keys are correctly set in environment variables
+
+
+### Getting Help
+
+- Check the [GitHub Issues](https://github.com/mozilla-ai/agent-factory/issues) for known problems
+- Review individual server documentation for specific troubleshooting steps
+
+## Testing and Maintenance
+
+### Automated Testing Workflow
+
+The MCP servers are automatically tested using the following workflow:
+
+1. **Manual Trigger**: Tests are run manually via GitHub Actions workflow dispatch
+2. **Server Testing**: The `docs/scripts/test_mcp_servers.py` script tests each server by:
+   - Attempting to connect to each MCP server
+   - Listing available tools
+   - Recording success/failure status and tool count
+3. **Results Storage**: Test results are saved to `.cache/mcp-test-results.json`
+4. **Documentation Update**: The `docs/scripts/generate_mcp_table.py` script generates this markdown file from the template with current test results
+
+### Running Tests Locally
+
+To test MCP servers locally:
+
+```bash
+# Run the test script
+uv run python -m docs.scripts.test_mcp_servers
+
+# Update the documentation
+uv run python -m docs.scripts.generate_mcp_table
+```
+
+## Contributing
+
+We welcome contributions to expand our MCP server coverage! To add a new MCP server:
+
+1. **Edit the JSON configuration**: Add a new entry to `docs/mcp-servers.json` in the `mcpServers` object:
+   ```json
+   "new-server-name": {
+     "command": "npx",
+     "args": ["-y", "@package/name"],
+     "env": {
+       "API_KEY": "YOUR_API_KEY_HERE"
+     },
+     "description": "Description of what this server does"
+   }
+   ```
+
+2. **Test the server**: Run the test script via the manually triggered Github Action.
+
+## References
+
+- [Model Context Protocol Documentation](https://modelcontextprotocol.io/)
+- [Agent Factory GitHub Repository](https://github.com/mozilla-ai/agent-factory)

--- a/docs/user-guide/mcp-servers-template.md
+++ b/docs/user-guide/mcp-servers-template.md
@@ -56,9 +56,9 @@ The MCP servers are automatically tested using the following workflow:
 
 1. **Manual Trigger**: Tests are run manually via GitHub Actions workflow dispatch
 2. **Server Testing**: The `docs/scripts/test_mcp_servers.py` script tests each server by:
-   - Attempting to connect to each MCP server
-   - Listing available tools
-   - Recording success/failure status and tool count
+    - Attempting to connect to each MCP server
+    - Listing available tools
+    - Recording success/failure status and tool count
 3. **Results Storage**: Test results are saved to `.cache/mcp-test-results.json`
 4. **Documentation Update**: The `docs/scripts/generate_mcp_table.py` script generates this markdown file from the template with current test results
 

--- a/docs/user-guide/mcp-servers.md
+++ b/docs/user-guide/mcp-servers.md
@@ -2,7 +2,7 @@
 
 This page lists the available Model Context Protocol (MCP) servers that can be used with Agent Factory. These servers extend the capabilities of your AI agents by providing access to various services, APIs, and data sources.
 
-> **⚠️ Note: This page is automatically generated and should not be manually edited.**
+> **⚠️ Note: This page is automatically generated, from a template and test results, and should not be manually edited.**
 > To add a new MCP server, edit the `docs/mcp-servers.json` file. Tests will be run automatically and results will be published in the table below.
 
 
@@ -20,7 +20,7 @@ The following table provides a quick overview of tested MCP servers. For detaile
 
 <!-- MCP_SERVERS_TABLE_START -->
 
-*Last updated: 2025-08-06T13:26:15.223852+00:00*
+*Last updated: 2025-08-06T18:54:30.088231+00:00*
 *Test results: 14 working, 1 failed, 1 skipped out of 16 total servers*
 
 | Server Name | Installation | Protocol | Status | Description |
@@ -28,7 +28,7 @@ The following table provides a quick overview of tested MCP servers. For detaile
 | **Github** | `docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN mcp/github` | stdio | ⏭️ Skipped | GitHub integration for repository management, issues, and code search |
 | **Filesystem** | `npx -y @modelcontextprotocol/server-filesystem . .` | stdio | ✅ Confirmed | Local file system operations and management |
 | **Duckduckgo-Mcp** | `uvx duckduckgo-mcp-server` | stdio | ✅ Confirmed | Web search capabilities using DuckDuckGo |
-| **Mcp-Obsidian** | `npx -y @smithery/cli@latest run mcp-obsidian --config "{\"vaultPath\":\"./test-vault\"}"` | stdio | ✅ Confirmed | Obsidian vault integration for note management |
+| **Mcp-Obsidian** | `npx -y @smithery/cli@latest run mcp-obsidian --config "{\"vaultPath\":\"./test-vault\"}"` | stdio | ❌ Failed | Obsidian vault integration for note management |
 | **Mcp-Discord** | `npx -y mcp-discord --config $DISCORD_TOKEN` | stdio | ✅ Confirmed | Discord messaging and server management |
 | **Memory** | `npx -y @modelcontextprotocol/server-memory` | stdio | ✅ Confirmed | Memory management and persistence for MCP servers |
 | **Notion** | `npx -y @notionhq/notion-mcp-server` | stdio | ✅ Confirmed | Notion workspace integration for page management |
@@ -77,11 +77,11 @@ The MCP servers are automatically tested using the following workflow:
 
 1. **Manual Trigger**: Tests are run manually via GitHub Actions workflow dispatch
 2. **Server Testing**: The `docs/scripts/test_mcp_servers.py` script tests each server by:
-   - Attempting to connect to each MCP server
-   - Listing available tools
-   - Recording success/failure status and tool count
+    - Attempting to connect to each MCP server
+    - Listing available tools
+    - Recording success/failure status and tool count
 3. **Results Storage**: Test results are saved to `.cache/mcp-test-results.json`
-4. **Documentation Update**: The `docs/scripts/generate_mcp_table.py` script updates this markdown file with current test results
+4. **Documentation Update**: The `docs/scripts/generate_mcp_table.py` script generates this markdown file from the template with current test results
 
 ### Running Tests Locally
 

--- a/docs/user-guide/mcp-servers.md
+++ b/docs/user-guide/mcp-servers.md
@@ -1,13 +1,22 @@
 # MCP Servers
 
+This page lists the available Model Context Protocol (MCP) servers that can be used with Agent Factory. These servers extend the capabilities of your AI agents by providing access to various services, APIs, and data sources.
+
 > **⚠️ Note: This page is automatically generated and should not be manually edited.**
 > To add a new MCP server, edit the `docs/mcp-servers.json` file. Tests will be run automatically and results will be published in the table below.
 
-This page provides a list of Model Context Protocol (MCP) servers configured for use with Agent Factory. These servers extend the capabilities of your AI agents by providing access to various services, APIs, and data sources.
+
+## Server Status Legend
+
+- ✅ **Confirmed**: Server has been tested and confirmed working
+- ⏭️ **Skipped**: Server was skipped during testing (Docker-based servers)
+- ❌ **Failed**: Server failed the latest test
+
 
 ## Quick Reference Table
 
 The following table provides a quick overview of tested MCP servers. For detailed information about each server, see the sections below.
+
 
 <!-- MCP_SERVERS_TABLE_START -->
 
@@ -19,7 +28,7 @@ The following table provides a quick overview of tested MCP servers. For detaile
 | **Github** | `docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN mcp/github` | stdio | ⏭️ Skipped | GitHub integration for repository management, issues, and code search |
 | **Filesystem** | `npx -y @modelcontextprotocol/server-filesystem . .` | stdio | ✅ Confirmed | Local file system operations and management |
 | **Duckduckgo-Mcp** | `uvx duckduckgo-mcp-server` | stdio | ✅ Confirmed | Web search capabilities using DuckDuckGo |
-| **Mcp-Obsidian** | `npx -y @smithery/cli@latest run mcp-obsidian --config "{\"vaultPath\":\"./test-vault\"}"` | stdio | ❌ Failed | Obsidian vault integration for note management |
+| **Mcp-Obsidian** | `npx -y @smithery/cli@latest run mcp-obsidian --config "{\"vaultPath\":\"./test-vault\"}"` | stdio | ✅ Confirmed | Obsidian vault integration for note management |
 | **Mcp-Discord** | `npx -y mcp-discord --config $DISCORD_TOKEN` | stdio | ✅ Confirmed | Discord messaging and server management |
 | **Memory** | `npx -y @modelcontextprotocol/server-memory` | stdio | ✅ Confirmed | Memory management and persistence for MCP servers |
 | **Notion** | `npx -y @notionhq/notion-mcp-server` | stdio | ✅ Confirmed | Notion workspace integration for page management |
@@ -34,19 +43,6 @@ The following table provides a quick overview of tested MCP servers. For detaile
 | **Gitlab** | `npx -y @modelcontextprotocol/server-gitlab` | stdio | ✅ Confirmed | GitLab API integration for project management and repository operations |
 <!-- MCP_SERVERS_TABLE_END -->
 
-## Server Status Legend
-
-- ✅ **Confirmed**: Server has been tested and confirmed working
-- ⏭️ **Skipped**: Server was skipped during testing (Docker-based servers)
-- ❌ **Failed**: Server failed the latest test
-
-## Content Processing
-
-### Text Processing Tools
-- **Extract Text from Markdown/HTML**: Built-in tool for content extraction
-- **Summarize Text with LLM**: AI-powered text summarization
-- **Translate Text with LLM**: Multi-language text translation
-- **Generate Podcast Script with LLM**: AI-generated content creation
 
 ## Installation & Setup
 
@@ -55,9 +51,10 @@ The following table provides a quick overview of tested MCP servers. For detaile
 Before installing MCP servers, ensure you have:
 
 1. **Node.js** (for npx installations)
-2. **Docker** (for containerized servers)
-3. **uv** (for uvx installations)
-4. **Proper API keys** for the services you want to use
+2. **uv** (for uvx installations)
+3. **Proper API keys** for the services you want to use
+
+Please note that **Docker**-based MCP servers are not supported as this time.
 
 ## Troubleshooting
 
@@ -65,14 +62,12 @@ Before installing MCP servers, ensure you have:
 
 1. **Permission Errors**: Ensure proper permissions for file system access
 2. **API Key Issues**: Verify API keys are correctly set in environment variables
-3. **Network Connectivity**: Check internet connection for remote services
-4. **Version Compatibility**: Ensure server versions are compatible with your Agent Factory version
+
 
 ### Getting Help
 
 - Check the [GitHub Issues](https://github.com/mozilla-ai/agent-factory/issues) for known problems
 - Review individual server documentation for specific troubleshooting steps
-- Join our community discussions for support
 
 ## Testing and Maintenance
 
@@ -122,7 +117,3 @@ We welcome contributions to expand our MCP server coverage! To add a new MCP ser
 
 - [Model Context Protocol Documentation](https://modelcontextprotocol.io/)
 - [Agent Factory GitHub Repository](https://github.com/mozilla-ai/agent-factory)
-
----
-
-*Last updated: Based on [Mozilla AI Agent Factory Wiki](https://github.com/mozilla-ai/agent-factory/wiki/MCP-servers-under-test)*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,3 +57,7 @@ nav:
     - Installation: getting-started/installation.md
   - User Guide:
     - MCP Servers: user-guide/mcp-servers.md
+    
+exclude_docs: |
+  user-guide/mcp-servers-template.md
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,59 @@
+site_name: Agent Factory
+site_url: https://mozilla-ai.github.io/agent-factory/
+repo_name: mozilla-ai/agent-factory
+repo_url: https://github.com/mozilla-ai/agent-factory
+docs_dir: docs
+
+extra_css: []
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      accent: grey
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: black
+      accent: grey
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+  font:
+    text: Roboto
+    code: JetBrains Mono
+  features:
+    - navigation.instant
+    - navigation.sections
+    - toc.integrate
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - attr_list
+  - md_in_html
+  - pymdownx.blocks.caption
+  - toc:
+      permalink: true
+
+plugins:
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [src]
+          options:
+            show_source: true
+            show_root_heading: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Installation: getting-started/installation.md
+  - User Guide:
+    - MCP Servers: user-guide/mcp-servers.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,6 @@ nav:
     - Installation: getting-started/installation.md
   - User Guide:
     - MCP Servers: user-guide/mcp-servers.md
-    
+
 exclude_docs: |
   user-guide/mcp-servers-template.md
-


### PR DESCRIPTION
## 📝 What's changing

* Added new gha to build documentation and publish on github.io
* Minimal initial docu taken from the readme
* Updates paths that generate the mcp-servers page
* Simplifies the mcp server page (no mention of factory scripts here now)

> If this PR is related to an issue or closes one, please link it here.

Refs #220 

Closes #220 

---

## 📚 How to test it

Steps to test the changes:

1. make docs-build && make docs-serve  
2. See docu locally
3. Navigate to 

---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [NA] Added some tests for any new functionality
- [X] Tested the changes in a working environment to ensure they work as expected
- [X] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [https://github.com/mozilla-ai/agent-factory/actions/runs/16776177954]
  >Note: The can be done from [Actions tab in GitHub UI](https://github.com/mozilla-ai/agent-factory/actions/workflows/tests.yaml) -> Select the pinned `Tests` workflow from the left sidebar -> Select `your-branch-name` -> `Run workflow`

---

## 📸 Screenshots (if applicable)

Please add any relevant screenshots to show the changes (e.g. agent performance in comparison to `main` branch).
