### PR TITLE
Rename AWS-related environment variables

### DIFF
--- a/.default.env
+++ b/.default.env
@@ -7,8 +7,8 @@ STORAGE_BACKEND=local
 ## AWS/MinIO Credentials
 # AWS_ACCESS_KEY_ID=agent-factory
 # AWS_SECRET_ACCESS_KEY=agent-factory # pragma: allowlist secret
-# AWS_DEFAULT_REGION=us-east-2
-# S3_BUCKET=agent-factory-outputs
+# AWS_REGION=us-east-1
+# S3_BUCKET_NAME=agent-factory-outputs
 
 ## MinIO Specific Endpoint (leave empty for AWS S3)
 # AWS_ENDPOINT_URL=http://localhost:9000

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ To customize the S3/MinIO configuration, you can create a `.env` file in the pro
 -   `STORAGE_BACKEND`: Set to `s3` for AWS S3 or `minio` for MinIO.
 -   `AWS_ACCESS_KEY_ID`: Your AWS or MinIO access key.
 -   `AWS_SECRET_ACCESS_KEY`: Your AWS or MinIO secret key.
--   `AWS_DEFAULT_REGION`: The AWS region for your S3 bucket.
--   `S3_BUCKET`: The name of the S3 or MinIO bucket.
+-   `AWS_REGION`: The AWS region for your S3 bucket.
+-   `S3_BUCKET_NAME`: The name of the S3 or MinIO bucket.
 -   `AWS_ENDPOINT_URL`: **(For MinIO only)** The URL of your MinIO instance (e.g., `http://localhost:9000`).
 
 When using these settings, the application will automatically create the specified bucket if it does not already exist.

--- a/src/agent_factory/utils/storage.py
+++ b/src/agent_factory/utils/storage.py
@@ -47,8 +47,8 @@ class S3Storage(StorageBackend):
     def __init__(self):
         self.aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
         self.aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
-        self.aws_region = os.environ["AWS_DEFAULT_REGION"]
-        self.bucket_name = os.environ["S3_BUCKET"]
+        self.aws_region = os.environ["AWS_REGION"]
+        self.bucket_name = os.environ["S3_BUCKET_NAME"]
         self.endpoint_url = os.environ.get("AWS_ENDPOINT_URL") or None
         self.storage_str = "S3" if self.endpoint_url is None else "MinIO"
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -78,8 +78,8 @@ def mock_s3_environ():
         {
             "AWS_ACCESS_KEY_ID": "test-key",  # pragma: allowlist secret
             "AWS_SECRET_ACCESS_KEY": "test-secret",  # pragma: allowlist secret
-            "AWS_DEFAULT_REGION": "us-east-1",
-            "S3_BUCKET": "test-bucket",
+            "AWS_REGION": "us-east-1",
+            "S3_BUCKET_NAME": "test-bucket",
         },
     ) as patched_environ:
         yield patched_environ


### PR DESCRIPTION
## 📝 What's changing

Rename the AWS-related environment variables to follow the conventions we use throughout our repos.

---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [ ] Added some tests for any new functionality
- [x] Tested the changes in a working environment to ensure they work as expected
- [x] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [insert-link-here]
  >Note: The can be done from [Actions tab in GitHub UI](https://github.com/mozilla-ai/agent-factory/actions/workflows/tests.yaml) -> Select the pinned `Tests` workflow from the left sidebar -> Select `your-branch-name` -> `Run workflow`