### PR TITLE
(fix) inputSchema not available via mcpd

### DIFF
--- a/src/agent_factory/factory_tools.py
+++ b/src/agent_factory/factory_tools.py
@@ -11,7 +11,7 @@ def _cleanup_mcp_server_info(server_info):
         server_info.pop(k, None)
 
     for tool in server_info.get("tools", []):
-        tool.pop("inputSchema")
+        tool.pop("inputSchema", None)
 
     return server_info
 


### PR DESCRIPTION
## 📝 What's changing
With `mcpd v0.0.3` the inputSchema field has been dropped from the tool schema:
https://github.com/mozilla-ai/mcpd/blob/1bd30610918d657e9c1e64f26e4b5d189c6f33b6/internal/packages/tools.go#L10-L30

> If this PR is related to an issue or closes one, please link it here.

Refs #...

Closes #...

---

## 📚 How to test it

Steps to test the changes:

1.
2.
3.

---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [ ] Added some tests for any new functionality
- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [insert-link-here]
  >Note: The can be done from [Actions tab in GitHub UI](https://github.com/mozilla-ai/agent-factory/actions/workflows/tests.yaml) -> Select the pinned `Tests` workflow from the left sidebar -> Select `your-branch-name` -> `Run workflow`

---

## 📸 Screenshots (if applicable)

Please add any relevant screenshots to show the changes (e.g. agent performance in comparison to `main` branch).
