### PR TITLE
Reduce duplication in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ clean: stop # Remove Docker containers and images
 
 check-prompt-id-present:
 	@if [ -z "$(PROMPT_ID)" ]; then \
-		echo "Error: PROMPT_ID is required. Usage: make $(MAKECMDGOALS) PROMPT_ID=<prompt-id> [UPDATE_ARTIFACTS=--update-artifacts]"; \
+		echo "Error: PROMPT_ID is required. Usage: make $(MAKECMDGOALS) PROMPT_ID=<prompt-id>"; \
 		exit 1; \
 	fi
 


### PR DESCRIPTION
## 📝 What's changing

Using `DOCKER_RUN_ARGS` that can be reused between `run` and `run-detached` make targets.

Introduced new targets that can be shared elsewhere:
- check-prompt-id-present
- check-env

---

## 📚 How to test it

Steps to test the changes:
Try testing the different make commands:
1. make run
or
2. make test-single-turn-generation-e2e PROMPT_ID=summarize-url-content


---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [ ] Added some tests for any new functionality
- [x] Tested the changes in a working environment to ensure they work as expected
- [x] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [[link-here](https://github.com/mozilla-ai/agent-factory/actions/runs/16883225369)]

---

## 📸 Screenshots (if applicable)

Please add any relevant screenshots to show the changes (e.g. agent performance in comparison to `main` branch).
