### PR TITLE
feat: eval uses npx filesystem mcp server, not docker

### DIFF
--- a/eval/generate_evaluation_case.py
+++ b/eval/generate_evaluation_case.py
@@ -37,9 +37,8 @@ def main(generated_workflow_dir: str = "generated_workflows/latest"):
     repo_root = Path.cwd()
     workflows_dir = repo_root / generated_workflow_dir
 
-    # Create a separate directory for file operations
-    file_ops_dir = "/app"
-    mount_workflows_dir = f"/app/{generated_workflow_dir}"
+    # The filesystem MCP server will work with the local directory directly
+    file_ops_dir = str(workflows_dir)
 
     framework = AgentFramework.OPENAI
     agent = AnyAgent.create(
@@ -51,18 +50,12 @@ def main(generated_workflow_dir: str = "generated_workflows/latest"):
                 visit_webpage,
                 search_tavily,
                 MCPStdio(
-                    command="docker",
+                    command="npx",
                     args=[
-                        "run",
-                        "-i",
-                        "--rm",
-                        "--volume",
-                        "/app",
-                        # Mount workflows directory
-                        "--mount",
-                        f"type=bind,src={workflows_dir},dst={mount_workflows_dir}",
-                        "mcp/filesystem",
+                        "-y",
+                        "@modelcontextprotocol/server-filesystem",
                         file_ops_dir,
+                        ".",
                     ],
                     tools=[
                         "read_file",


### PR DESCRIPTION
## 📝 What's changing

Switched the MCP server for Filesystem from docker to npx based, so that the platform can run it.

> If this PR is related to an issue or closes one, please link it here.

Refs #239 

Closes #239 

---

## 📚 How to test it

Steps to test the changes:

1. Launch the server in nochat mode: `cd src/agent_factory && uv run . --host 0.0.0.0 --port 8080 --nochat`
2. Different terminal, create a new agent: `uv run agent-factory "Summarize text content from a given webpage URL. Make assumptions but don't ask for more input.`
3. Run the agent: `cd generated_workflows/$SOME_ID &&  uv run --with-requirements requirements.txt --python 3.13 python agent.py --url https://cookbook.openai.com/examples/gpt-5/gpt-5_new_params_and_tools`
4. Evaluate the agent (this is the step likely to fail, should there be a problem): `uv run python -m eval.generate_evaluation_case generated_workflows/$SOME_ID/`

---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [NA (no new functionality)] Added some tests for any new functionality
- [X] Tested the changes in a working environment to ensure they work as expected
- [X] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [here](https://github.com/mozilla-ai/agent-factory/actions/runs/16888988037)
  >Note: The can be done from [Actions tab in GitHub UI](https://github.com/mozilla-ai/agent-factory/actions/workflows/tests.yaml) -> Select the pinned `Tests` workflow from the left sidebar -> Select `your-branch-name` -> `Run workflow`


