### PR TITLE
chore: fix deployed pages not using material theme

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,65 +8,48 @@ on:
       - 'docs/**'
       - 'src/**'
       - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
       - 'pyproject.toml'
   pull_request:
-    branches:
-      - main
     paths:
       - 'docs/**'
       - 'src/**'
       - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
       - 'pyproject.toml'
+  workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  contents: write
 
 jobs:
-  # Build docs
-  build:
+  docs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
         with:
-          python-version: '3.13'
+          fetch-depth: 0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
         with:
-          version: latest
+          python-version: 3.13
+          activate-environment: true
 
       - name: Install dependencies
         run: |
           uv sync --group docs
 
-      - name: Build documentation
+      - name: Configure git
         run: |
-          uv run mkdocs build
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./site
+      - name: Build documentation
+        if: github.event_name == 'pull_request'
+        run: uv run mkdocs build -s
 
-  # Deploy docs
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Publish docs
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        run: uv run mkdocs gh-deploy


### PR DESCRIPTION
## 📝 What's changing

Fixes not using the material theme by serving docu avoiding jekyll. 

For this, we now use gh-deploy like other recent public repos we have ([any-llm](https://github.com/mozilla-ai/any-llm/blob/main/.github/workflows/docs.yaml), [mcpd](https://github.com/mozilla-ai/mcpd/blob/main/.github/workflows/deploy-docs.yaml)).

---

## 📚 How to test it

Steps to test the changes:

1. `uv run mkdocs build -s`
2. `uv run mkdocs serve` to check locally


---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [NA] Added some tests for any new functionality
- [X] Tested the changes in a working environment to ensure they work as expected
- [NA] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [insert-link-here]
  >Note: The can be done from [Actions tab in GitHub UI](https://github.com/mozilla-ai/agent-factory/actions/workflows/tests.yaml) -> Select the pinned `Tests` workflow from the left sidebar -> Select `your-branch-name` -> `Run workflow`

