### PR TITLE
refactor(artifact): adds litellm<1.75.0 to all target agents

### DIFF
--- a/src/agent_factory/utils/artifact_validation.py
+++ b/src/agent_factory/utils/artifact_validation.py
@@ -17,14 +17,28 @@ def clean_python_code_with_autoflake(code: str) -> str:
         raise
 
 
+# TODO: pin all dependencies, if known, i.e. if present in the pyproject.toml
 def validate_dependencies(agent_factory_outputs: dict[str, str]) -> str:
     """Validate dependencies. In particular:
     - make sure that if uvx is used to install an MCP server, then
       uv appears in the final requirements.txt
+    - Any line starting with `litellm` (optionally with extras and any version
+      specifiers) is replaced with exactly `litellm<1.75.0`.
+    - If no `litellm` line exists and dependencies are non-empty, append
+      `litellm<1.75.0` as a new line.
     """
-    # make sure uv is in if uvx is in tools
-    if "uvx" in agent_factory_outputs["tools"] and "uv" not in agent_factory_outputs["dependencies"]:
-        logger.info("Agent uses uvx but deps were missing uv: adding manually.")
-        agent_factory_outputs["dependencies"] += "\nuv"
+    dependencies = agent_factory_outputs["dependencies"]
 
-    return agent_factory_outputs["dependencies"]
+    # make sure uv is in if uvx is in tools
+    if "uvx" in agent_factory_outputs["tools"] and "uv" not in dependencies:
+        logger.info("Agent uses uvx but deps were missing uv: adding manually.")
+        dependencies += "\nuv"
+
+    # Remove any existing litellm lines and append pinned constraint
+    lines = dependencies.split("\n")
+    filtered_lines = [line for line in lines if not line.strip().startswith("litellm")]
+    filtered_lines.append("litellm<1.75.0")
+
+    normalized_dependencies = "\n".join(filtered_lines)
+    agent_factory_outputs["dependencies"] = normalized_dependencies
+    return normalized_dependencies

--- a/tests/unit/test_artifact_validation.py
+++ b/tests/unit/test_artifact_validation.py
@@ -1,0 +1,56 @@
+"""Tests for artifact validation utilities."""
+
+import pytest
+
+from agent_factory.utils.artifact_validation import validate_dependencies
+
+
+class TestValidateDependencies:
+    """Test the validate_dependencies function."""
+
+    def test_basic_validation_adds_litellm(self, sample_generator_agent_response_json):
+        """Test that litellm<1.75.0 is added to typical agent dependencies."""
+        agent_factory_outputs = sample_generator_agent_response_json.copy()
+
+        result = validate_dependencies(agent_factory_outputs)
+
+        expected = sample_generator_agent_response_json["dependencies"] + "\nlitellm<1.75.0"
+        assert result == expected
+        assert agent_factory_outputs["dependencies"] == expected
+
+    @pytest.mark.parametrize(
+        "litellm_dep,expected_suffix",
+        [
+            ("litellm", "litellm<1.75.0"),
+            ("litellm=>1.73.0", "litellm<1.75.0"),
+            ("litellm[proxy]==1.80.0", "litellm<1.75.0"),
+        ],
+    )
+    def test_replaces_existing_litellm_versions(
+        self, sample_generator_agent_response_json, litellm_dep, expected_suffix
+    ):
+        """Test that existing litellm versions are replaced with pinned version."""
+        agent_factory_outputs = sample_generator_agent_response_json.copy()
+        agent_factory_outputs["dependencies"] = (
+            sample_generator_agent_response_json["dependencies"] + f"\n{litellm_dep}"
+        )
+
+        result = validate_dependencies(agent_factory_outputs)
+
+        expected = sample_generator_agent_response_json["dependencies"] + f"\n{expected_suffix}"
+        assert result == expected
+        assert result.count("litellm<1.75.0") == 1
+
+    def test_adds_uv_when_uvx_in_tools(self, sample_generator_agent_response_json):
+        """Test that uv is added when uvx is found in tools."""
+        agent_factory_outputs = sample_generator_agent_response_json.copy()
+        # Modify tools to include uvx usage (realistic scenario)
+        agent_factory_outputs["tools"] = (
+            sample_generator_agent_response_json["tools"] + "\n# uvx install some-mcp-server"
+        )
+
+        result = validate_dependencies(agent_factory_outputs)
+
+        expected = sample_generator_agent_response_json["dependencies"] + "\nuv\nlitellm<1.75.0"
+        assert result == expected
+        assert agent_factory_outputs["dependencies"] == expected


### PR DESCRIPTION
## 📝 What's changing

Only pins LiteLLM to fix the problem we're having in #261  and enable running the agents.

Full searching for the versions and pinning in #267 

> If this PR is related to an issue or closes one, please link it here.

Closes #261 

---

## 📚 How to test it

Steps to test the changes:

1. `make run`
2. `uv run chainlit run src/agent_factory/chainlit.py`
3. Create a new agent
4. Its requirements.txt should list litellm<1.75.0
5. Run the agent, no "No module backoff" error anymore

---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [X] Added some tests for any new functionality
- [X] Tested the changes in a working environment to ensure they work as expected
- [X] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [here](https://github.com/mozilla-ai/agent-factory/actions/runs/16978693650)
  >Note: The can be done from [Actions tab in GitHub UI](https://github.com/mozilla-ai/agent-factory/actions/workflows/tests.yaml) -> Select the pinned `Tests` workflow from the left sidebar -> Select `your-branch-name` -> `Run workflow`
