### PR TITLE
Bring back unit tests on factory tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ check-prompt-id-present:
 test-unit: ## Run unit tests
 	@uv sync --quiet --group tests
 	@pytest -v tests/unit/
+	@pytest -v tests/tools/
 	@echo "Unit tests completed successfully!"
 
 wait-for-server:


### PR DESCRIPTION
## 📝 What's changing

During test migration, unit tests on factory tools were mistakenly removed from CI.
This PR brings it back to the makefile under `test-unit` which is what is use in the CI.

---

## 📚 How to test it

Steps to test the changes:
```
make test-unit
```

---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [ ] Added some tests for any new functionality
- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [insert-link-here]
  >Note: The can be done from [Actions tab in GitHub UI](https://github.com/mozilla-ai/agent-factory/actions/workflows/tests.yaml) -> Select the pinned `Tests` workflow from the left sidebar -> Select `your-branch-name` -> `Run workflow`

---

## 📸 Screenshots (if applicable)

Please add any relevant screenshots to show the changes (e.g. agent performance in comparison to `main` branch).
