### PR TITLE
Added uses_mcpd in use cases, used it in tests to assert_generated_files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,10 +58,10 @@ def min_successes(request, use_cases):
 
 
 @pytest.fixture(scope="session")
-def uses_mcpd(request, use_cases):
-    """Fixture to provide uses_mcpd from the use case YAML based on --prompt-id."""
+def requires_mcpd(request, use_cases):
+    """Fixture to provide requires_mcpd from the use case YAML based on --prompt-id."""
     prompt_id = request.config.getoption("--prompt-id")
-    return use_cases[prompt_id]["uses_mcpd"]
+    return use_cases[prompt_id]["requires_mcpd"]
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,13 @@ def min_successes(request, use_cases):
 
 
 @pytest.fixture(scope="session")
+def uses_mcpd(request, use_cases):
+    """Fixture to provide uses_mcpd from the use case YAML based on --prompt-id."""
+    prompt_id = request.config.getoption("--prompt-id")
+    return use_cases[prompt_id]["uses_mcpd"]
+
+
+@pytest.fixture(scope="session")
 def agent_dir(artifacts_dir: Path, prompt_id: str) -> Path:
     """Fixture to get the agent directory path for the current prompt."""
     return artifacts_dir / prompt_id

--- a/tests/generation/test_single_turn_generation.py
+++ b/tests/generation/test_single_turn_generation.py
@@ -14,9 +14,11 @@ from agent_factory.agent_generator import generate_target_agent
 from agent_factory.utils.client_utils import is_server_live
 
 
-def _assert_generated_files(workflow_dir: Path):
+def _assert_generated_files(workflow_dir: Path, uses_mcpd: bool):
     existing_files = [f.name for f in workflow_dir.iterdir()]
     expected_files = ["agent.py", "README.md", "requirements.txt", "agent_parameters.json"]
+    if uses_mcpd:
+        expected_files.extend([".env", ".mcpd.toml", "secrets.prod.toml"])
 
     for expected_file in expected_files:
         assert expected_file in existing_files, f"{expected_file} was not generated."
@@ -37,6 +39,7 @@ async def test_single_turn_generation(
     tmp_path: Path,
     request: pytest.FixtureRequest,
     use_cases: dict,
+    uses_mcpd: bool,
     max_attempts: int,
     min_successes: int,
 ):
@@ -58,7 +61,7 @@ async def test_single_turn_generation(
     await generate_target_agent(message=test_case["prompt"], output_dir=full_path)
 
     # Verify the expected files were generated
-    _assert_generated_files(full_path)
+    _assert_generated_files(full_path, uses_mcpd)
 
     # Verify the generated agent.py has valid Python syntax
     agent_file = full_path / "agent.py"

--- a/tests/generation/test_single_turn_generation.py
+++ b/tests/generation/test_single_turn_generation.py
@@ -15,17 +15,27 @@ from agent_factory.utils.client_utils import is_server_live
 
 
 def _assert_generated_files(workflow_dir: Path, requires_mcpd: bool):
-    existing_files = [f.name for f in workflow_dir.iterdir()]
-    expected_files = ["agent.py", "README.md", "requirements.txt", "agent_parameters.json"]
+    """Makes sure all and only the expected files are generated for each agent.
+
+    Every agent has a set of expected_files. Only those agents requiring mcpd
+    have a few extra ones. (NOTE: .gitignore is currently always present even
+    if agents which don't require mcpd don't need it).
+
+    Parameters:
+    - workflow_dir: the directory where the agent resides
+    - requires_mcpd: a parameter specifying whether the agent requires
+      mcpd to work (this information is stored in `use_cases.yaml`)
+    """
+    existing_files = [f.name for f in workflow_dir.iterdir() if not f.is_dir()]
+    expected_files = [".gitignore", "agent.py", "README.md", "requirements.txt", "agent_parameters.json"]
     if requires_mcpd:
         expected_files.extend([".env", ".mcpd.toml", "secrets.prod.toml"])
 
     for expected_file in expected_files:
         assert expected_file in existing_files, f"{expected_file} was not generated."
 
-    extra_python_files = [f for f in existing_files if f.endswith(".py") and f != "agent.py"]
-    assert len(extra_python_files) == 0, (
-        f"Unexpected Python files found: {extra_python_files}. Only 'agent.py' should be generated."
+    assert set(existing_files) == set(expected_files), (
+        f"Extra files were generated: {set(existing_files) - set(expected_files)}"
     )
 
 

--- a/tests/generation/test_single_turn_generation.py
+++ b/tests/generation/test_single_turn_generation.py
@@ -14,10 +14,10 @@ from agent_factory.agent_generator import generate_target_agent
 from agent_factory.utils.client_utils import is_server_live
 
 
-def _assert_generated_files(workflow_dir: Path, uses_mcpd: bool):
+def _assert_generated_files(workflow_dir: Path, requires_mcpd: bool):
     existing_files = [f.name for f in workflow_dir.iterdir()]
     expected_files = ["agent.py", "README.md", "requirements.txt", "agent_parameters.json"]
-    if uses_mcpd:
+    if requires_mcpd:
         expected_files.extend([".env", ".mcpd.toml", "secrets.prod.toml"])
 
     for expected_file in expected_files:
@@ -39,7 +39,7 @@ async def test_single_turn_generation(
     tmp_path: Path,
     request: pytest.FixtureRequest,
     use_cases: dict,
-    uses_mcpd: bool,
+    requires_mcpd: bool,
     max_attempts: int,
     min_successes: int,
 ):
@@ -61,7 +61,7 @@ async def test_single_turn_generation(
     await generate_target_agent(message=test_case["prompt"], output_dir=full_path)
 
     # Verify the expected files were generated
-    _assert_generated_files(full_path, uses_mcpd)
+    _assert_generated_files(full_path, requires_mcpd)
 
     # Verify the generated agent.py has valid Python syntax
     agent_file = full_path / "agent.py"

--- a/tests/generation/use_cases.yaml
+++ b/tests/generation/use_cases.yaml
@@ -13,6 +13,7 @@ summarize-url-content:
   expected_execution_time: 120
   max_attempts: 5
   min_successes: 4
+  uses_mcpd: false
 
 # Agent with MCP single MCP server (ElevenLabs)
 url-to-podcast:
@@ -27,6 +28,7 @@ url-to-podcast:
   expected_execution_time: 420
   max_attempts: 5
   min_successes: 3
+  uses_mcpd: true
 
 # Agent with multiple MCP servers (Slack and SQLite)
 scoring-blueprints-submission:
@@ -44,3 +46,4 @@ scoring-blueprints-submission:
   expected_execution_time: 420
   max_attempts: 5
   min_successes: 4
+  uses_mcpd: true

--- a/tests/generation/use_cases.yaml
+++ b/tests/generation/use_cases.yaml
@@ -13,7 +13,7 @@ summarize-url-content:
   expected_execution_time: 120
   max_attempts: 5
   min_successes: 4
-  uses_mcpd: false
+  requires_mcpd: false
 
 # Agent with MCP single MCP server (ElevenLabs)
 url-to-podcast:
@@ -28,7 +28,7 @@ url-to-podcast:
   expected_execution_time: 420
   max_attempts: 5
   min_successes: 3
-  uses_mcpd: true
+  requires_mcpd: true
 
 # Agent with multiple MCP servers (Slack and SQLite)
 scoring-blueprints-submission:
@@ -46,4 +46,4 @@ scoring-blueprints-submission:
   expected_execution_time: 420
   max_attempts: 5
   min_successes: 4
-  uses_mcpd: true
+  requires_mcpd: true


### PR DESCRIPTION
## 📝 What's changing

With the new mcpd integration, some generated agents (those who make use of mcp tools) will have a few extra files created in their directory. We want to make sure that those files are present for all those use cases which rely on mcpd.

To do this:
- we have added a `uses_mcpd` parameter to `use_cases.yaml`
- we have added a check in `_assert_generated_files` so that if `uses_mcpd` is true we also check for the presence of `[".env", ".mcpd.toml", "secrets.prod.toml"]`

> If this PR is related to an issue or closes one, please link it here.

Closes #278 

---

## 📚 How to test it

Steps to test the changes:

1. make test-single-turn-generation-e2e PROMPT_ID=summarize-url-content (should succeed)
2. change `uses_mcpd` to `true` in `profiles.yaml` for `summarize-url-content` and rerun the test (should fail)
3. make test-single-turn-generation-e2e PROMPT_ID=url-to-podcast (should succeed)

---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [x] Added some tests for any new functionality
- [x] Tested the changes in a working environment to ensure they work as expected

---

## 📸 Screenshots (if applicable)

Please add any relevant screenshots to show the changes (e.g. agent performance in comparison to `main` branch).
