### PR TITLE
Update instructions on how to run mcpd daemon

### DIFF
--- a/src/agent_factory/instructions.py
+++ b/src/agent_factory/instructions.py
@@ -238,9 +238,9 @@ The final expected output is a dictionary with the following structure:
     # Run the Agent
 
     Add the following step only if you've chosen to use an MCP server:
-    1. Run the mcpd daemon:
+    1. Export your .env variables so they can be sourced by mcpd and run the mcpd daemon:
     ```bash
-    mcpd daemon --log-level=DEBUG --log-path=$(pwd)/mcpd.log --dev --runtime-file secrets.prod.toml
+    export $(cat .env | xargs) &&  mcpd daemon --log-level=DEBUG --log-path=$(pwd)/mcpd.log --dev --runtime-file secrets.prod.toml
     ```
 
     2. Run the agent:


### PR DESCRIPTION
## 📝 What's changing

Update the instructions of the manufacturing agent so that the generated README.md of the target agent includes the correct command on how to run the mcpd daemon locally.

Closes #289 

---

## 📚 How to test it

Steps to test the changes:

1. Start server: 
2. Generate an agent:
3. Verify the generated README.md has the expected instructions

---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [ ] Added some tests for any new functionality
- [ ] Tested the changes in a working environment to ensure they work as expected
- [ ] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [insert-link-here]
  >Note: The can be done from [Actions tab in GitHub UI](https://github.com/mozilla-ai/agent-factory/actions/workflows/tests.yaml) -> Select the pinned `Tests` workflow from the left sidebar -> Select `your-branch-name` -> `Run workflow`

---

## 📸 Screenshots (if applicable)

Please add any relevant screenshots to show the changes (e.g. agent performance in comparison to `main` branch).
