### PR TITLE
refactor(agent-factory): Clarify MCPd instructions and errors

### DIFF
--- a/src/agent_factory/instructions.py
+++ b/src/agent_factory/instructions.py
@@ -76,7 +76,10 @@ try:
         print("No tools found via mcpd.")
     TOOLS.extend(mcp_server_tools)
 except McpdError as e:
-    print(f"Error connecting to mcpd: {e}", file=sys.stderr)
+    print(
+        f"Error connecting to mcpd: {e}. If the agent doesn't use any MCP servers you can safely ignore this error",
+        file=sys.stderr
+    )
 
 # ========== Running the agent via CLI ===========
 agent = AnyAgent.create(
@@ -211,6 +214,8 @@ The final expected output is a dictionary with the following structure:
     # Prerequisites
 
     - uv
+
+    Add the following prerequisite only if you have chosen to use any MCP servers:
     - mcpd
 
     ## Install uv
@@ -220,20 +225,20 @@ The final expected output is a dictionary with the following structure:
         curl -LsSf https://astral.sh/uv/install.sh | sh
         ```
     - **Windows PowerShell**
-    ```powershell
-    powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
-    ```
+        ```powershell
+        powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+        ```
 
     Add this section about mcpd only if you've chosen to use any MCP servers:
     ## Install mcpd
 
     Follow the mcpd installation instructions in the official documentation: https://mozilla-ai.github.io/mcpd/installation/
 
+    Add this section about mcpd configuration only if you've chosen to use any MCP servers:
     # Configuration
 
-    Add this exact phrase here:
-    "Set the environment variables in the `.env` file that has been created for you. Add other environment variables as needed,
-    for example, environment variables for your LLM provider."
+    Set the environment variables in the `.env` file that has been created for you. Add other environment variables as needed,
+    for example, environment variables for your LLM provider.
 
     # Run the Agent
 
@@ -302,7 +307,10 @@ try:
         print("No tools found via mcpd.")
     TOOLS.extend(mcp_server_tools)
 except McpdError as e:
-    print(f"Error connecting to mcpd: {{e}}", file=sys.stderr)
+    print(
+        f"Error connecting to mcpd: {{e}}. If the agent doesn't use any MCP servers you can safely ignore this error",
+        file=sys.stderr
+    )
 
 # ========== Running the agent via CLI ===========
 agent = AnyAgent.create(


### PR DESCRIPTION
## 📝 What's changing

This PR improves the developer experience for users of generated agents by:

- Conditionally including mcpd instructions: The generated `README.md` now only includes installation and configuration instructions for mcpd if the generated agent actually uses tools from MCP servers. This avoids confusion for users whose agents don't have any MCP-related dependencies.
- Clarifying the mcpd connection error: The error message displayed when mcpd is not running has been updated to inform the user that it can be safely ignored if their agent does not use any MCP servers.

Closes #264

---

## 📚 How to test it

Run a workflow that doesn't require an MCP server. Check:
- The README.md of the generated agent should not include mcpd-related stuff.
- The error message during the generated agent execution should mention that it is safe to ignore.

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [ ] Added some tests for any new functionality
- [x] Tested the changes in a working environment to ensure they work as expected
- [x] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [insert-link-here]
  >Note: The can be done from [Actions tab in GitHub UI](https://github.com/mozilla-ai/agent-factory/actions/workflows/tests.yaml) -> Select the pinned `Tests` workflow from the left sidebar -> Select `your-branch-name` -> `Run workflow`
