### PR TITLE
Added mock for visit_webpage for summarise/pocdast use cases

### DIFF
--- a/tests/generated_artifacts/tool_mappings.py
+++ b/tests/generated_artifacts/tool_mappings.py
@@ -30,6 +30,11 @@ TOOL_MOCKS = [
     },
     {
         "prompt_id": "url-to-podcast",
+        "function_name": "visit_webpage",
+        "mock_function": mock_extract_text_from_url,
+    },
+    {
+        "prompt_id": "url-to-podcast",
         "function_name": "combine_mp3_files_for_podcast",
         "mock_function": mock_combine_mp3_files_for_podcast,
     },
@@ -51,6 +56,11 @@ TOOL_MOCKS = [
     {
         "prompt_id": "summarize-url-content",
         "function_name": "extract_text_from_url",
+        "mock_function": mock_extract_text_from_url,
+    },
+    {
+        "prompt_id": "summarize-url-content",
+        "function_name": "visit_webpage",
         "mock_function": mock_extract_text_from_url,
     },
 ]


### PR DESCRIPTION
## 📝 What's changing

Mocks are built to avoid our agents hitting actual services when testing. As in our tests we used a fake Wikipedia URL to mock page content, if the tool we are using for Web content retrieval is not mocked it will return an error.

Both our summarize-url and url-to-podcast use-cases rely on web retrieval tools, which can either be `extract_text_from_url` or `visit_webpage`. Only the former was mocked, but as both agents could sometimes be generated using the latter we want to mock that tool too.

This PR addresses this issue by adding matchings for `visit_webpage` in the use-cases mentioned above.

---

## 📚 How to test it

As both agents currently available in main use `extract_text_from_url`, to test this PR one should either regenerate one agent to use `visit_webpage` or update its code to do that (which is what I did for testing), then run (e.g. for the summarization use case):

```
make test-generated-artifacts-integration PROMPT_ID=summarize-url-content
```

and verify that instead of a 403 HTTP error the agent gets the content returned by the mock code.

---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [x] Tested the changes in a working environment to ensure they work as expected
- [x] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: https://github.com/mozilla-ai/agent-factory/actions/runs/17270168046