### PR TITLE
Fix failing eval tests after model switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ check-prompt-id-present:
 test-unit: ## Run unit tests
 	@uv run --group tests pytest -v tests/unit/
 	@uv run --group tests pytest -v tests/tools/
+	@uv run --group tests pytest -v tests/generated_agent_evaluation/unit/
 	@echo "Unit tests completed successfully!"
 
 wait-for-server:

--- a/tests/generated_agent_evaluation/integration/test_run_agent_evaluation.py
+++ b/tests/generated_agent_evaluation/integration/test_run_agent_evaluation.py
@@ -1,0 +1,25 @@
+import asyncio
+from unittest import mock
+
+from eval.run_generated_agent_evaluation import run_evaluation
+
+
+def test_evaluation_runs_with_valid_inputs(tmpdir, sample_evaluation_json_file, sample_agent_eval_trace_json):
+    """Tests that the evaluation script runs successfully with mock data."""
+    evaluation_case_path = tmpdir.join("evaluation_case.json")
+    evaluation_case_path.write(sample_evaluation_json_file)
+
+    agent_trace_path = tmpdir.join("agent_eval_trace.json")
+    agent_trace_path.write(sample_agent_eval_trace_json)
+
+    results_path = tmpdir.join("evaluation_results.json")
+
+    with mock.patch("builtins.print"):
+        # The run_evaluation function is async, so we need to await it
+        asyncio.run(
+            run_evaluation(
+                generated_workflow_dir=str(tmpdir),
+            )
+        )
+
+    assert results_path.exists(), "evaluation_results.json was not created"

--- a/tests/generated_agent_evaluation/test_run_agent_evaluation.py
+++ b/tests/generated_agent_evaluation/test_run_agent_evaluation.py
@@ -70,7 +70,7 @@ def test_evaluation_uses_default_model_and_framework(
     tmpdir, sample_evaluation_json_file: str, sample_agent_eval_trace_json: str
 ):
     """Tests that the AgentJudge uses the default model and framework when we do not provide anything."""
-    expected_default_model = "gpt-4.1"
+    expected_default_model = "o3"
     expected_default_framework = AgentFramework.TINYAGENT
 
     evaluation_case_path = tmpdir.join("evaluation_case.json")

--- a/tests/generated_agent_evaluation/unit/test_evaluation.py
+++ b/tests/generated_agent_evaluation/unit/test_evaluation.py
@@ -6,27 +6,6 @@ from any_agent import AgentFramework
 from eval.run_generated_agent_evaluation import run_evaluation
 
 
-def test_evaluation_runs_with_valid_inputs(tmpdir, sample_evaluation_json_file, sample_agent_eval_trace_json):
-    """Tests that the evaluation script runs successfully with mock data."""
-    evaluation_case_path = tmpdir.join("evaluation_case.json")
-    evaluation_case_path.write(sample_evaluation_json_file)
-
-    agent_trace_path = tmpdir.join("agent_eval_trace.json")
-    agent_trace_path.write(sample_agent_eval_trace_json)
-
-    results_path = tmpdir.join("evaluation_results.json")
-
-    with mock.patch("builtins.print"):
-        # The run_evaluation function is async, so we need to await it
-        asyncio.run(
-            run_evaluation(
-                generated_workflow_dir=str(tmpdir),
-            )
-        )
-
-    assert results_path.exists(), "evaluation_results.json was not created"
-
-
 @pytest.mark.parametrize(
     "custom_model,custom_framework",
     [


### PR DESCRIPTION
## 📝 What's changing

* Changed the expected default model `"gpt-4.1"` to `"o3"` to reflect the current default (after failing tests observed after merging #308).

This was not caught by the unit tests since they were running together with the integration tests which required manual trigger.

To avoid this in future, this PR refactors the eval tests into separate folders - unit and integration

* Moved the `test_evaluation_runs_with_valid_inputs` test to a new integration test file (since it uses LLM API key)

* Moved the remaining tests that don't need API keys to unit `tests/generated_agent_evaluation/unit/'

---

## 📚 How to test it

Steps to test the changes:

1. make test-unit
2. pytest -v tests/generated_agent_evaluation/integration 

---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [x] Added some tests for any new functionality
- [x] Tested the changes in a working environment to ensure they work as expected
- [x] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [[link-here](https://github.com/mozilla-ai/agent-factory/actions/runs/17318212594)]


---

## 📸 Screenshots (if applicable)

Please add any relevant screenshots to show the changes (e.g. agent performance in comparison to `main` branch).
