### PR TITLE
Add trace propagation support to chainlit

### DIFF
--- a/src/agent_factory/__main__.py
+++ b/src/agent_factory/__main__.py
@@ -1,26 +1,18 @@
 import dotenv
 import fire
-from opentelemetry import trace
 from opentelemetry.instrumentation.starlette import StarletteInstrumentor
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import (
-    SimpleSpanProcessor,
-)
 
 from agent_factory.config import TRACES_DIR
 from agent_factory.factory_tools import read_file, search_mcp_servers
 from agent_factory.instructions import load_system_instructions
 from agent_factory.schemas import AgentFactoryOutputs
 from agent_factory.utils import logger
-from agent_factory.utils.json_exporter import JsonFileSpanExporter
+from agent_factory.utils.tracing import setup_tracing
 
 dotenv.load_dotenv()
 
-
-trace.set_tracer_provider(TracerProvider())
-span_processor = SimpleSpanProcessor(JsonFileSpanExporter(TRACES_DIR))
-trace.get_tracer_provider().add_span_processor(span_processor)
-
+# Set up tracing (but don't instrument HTTPX since we'll use Starlette instrumentation)
+tracer = setup_tracing(TRACES_DIR, __name__, instrument_httpx=False)
 StarletteInstrumentor().instrument()
 
 

--- a/src/agent_factory/agent_generator.py
+++ b/src/agent_factory/agent_generator.py
@@ -6,10 +6,12 @@ import httpx
 from a2a.client import A2ACardResolver, A2AClient
 from dotenv import find_dotenv, load_dotenv
 from opentelemetry import trace
-from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
-from opentelemetry.sdk.trace import TracerProvider
 
-from agent_factory.config import TRACES_DIR
+from agent_factory.config import (
+    PUBLIC_AGENT_CARD_PATH,
+    EXTENDED_AGENT_CARD_PATH,
+    TRACES_DIR,
+)
 from agent_factory.schemas import Status
 from agent_factory.utils import (
     create_a2a_http_client,
@@ -22,13 +24,10 @@ from agent_factory.utils import (
     process_a2a_agent_final_response,
     process_streaming_response_message,
 )
+from agent_factory.utils.tracing import setup_tracing
 
-trace.set_tracer_provider(TracerProvider())
-HTTPXClientInstrumentor().instrument()
-tracer = trace.get_tracer(__name__)
-
-PUBLIC_AGENT_CARD_PATH = "/.well-known/agent.json"
-EXTENDED_AGENT_CARD_PATH = "/agent/authenticatedExtendedCard"
+# Set up tracing with HTTPX instrumentation
+tracer = setup_tracing(TRACES_DIR, __name__, instrument_httpx=True)
 
 
 async def generate_target_agent(

--- a/src/agent_factory/config.py
+++ b/src/agent_factory/config.py
@@ -14,3 +14,8 @@ if not TRACES_DIR.is_absolute():
     TRACES_DIR = PROJECT_ROOT / TRACES_DIR
 
 DEFAULT_EXPORT_PATH = PROJECT_ROOT / "generated_workflows"
+
+# A2A Protocol Constants
+PUBLIC_AGENT_CARD_PATH = "/.well-known/agent.json"
+EXTENDED_AGENT_CARD_PATH = "/agent/authenticatedExtendedCard"
+DEFAULT_TIMEOUT = 600  # 10 minutes

--- a/src/agent_factory/utils/__init__.py
+++ b/src/agent_factory/utils/__init__.py
@@ -10,6 +10,7 @@ from .client_utils import (
 from .io_utils import prepare_agent_artifacts
 from .logging import logger
 from .storage import get_storage_backend
+from .tracing import setup_tracing
 
 __all__ = [
     "clean_python_code_with_autoflake",
@@ -23,4 +24,5 @@ __all__ = [
     "create_agent_trace_from_dumped_spans",
     "get_storage_backend",
     "logger",
+    "setup_tracing",
 ]

--- a/src/agent_factory/utils/tracing.py
+++ b/src/agent_factory/utils/tracing.py
@@ -1,0 +1,38 @@
+"""Shared utilities for OpenTelemetry tracing setup."""
+
+from pathlib import Path
+
+from opentelemetry import trace
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from agent_factory.utils.json_exporter import JsonFileSpanExporter
+
+
+def setup_tracing(traces_dir: Path, service_name: str, instrument_httpx: bool = True) -> trace.Tracer:
+    """Set up OpenTelemetry tracing with JSON file export.
+    
+    Args:
+        traces_dir: Directory to save trace files
+        service_name: Name of the service for the tracer
+        instrument_httpx: Whether to instrument HTTPX client
+        
+    Returns:
+        Configured tracer instance
+    """
+    # Ensure traces directory exists
+    traces_dir.mkdir(exist_ok=True, parents=True)
+    
+    # Set up tracer provider
+    trace.set_tracer_provider(TracerProvider())
+    
+    # Add JSON file exporter
+    span_processor = SimpleSpanProcessor(JsonFileSpanExporter(traces_dir))
+    trace.get_tracer_provider().add_span_processor(span_processor)
+    
+    # Instrument HTTPX if requested
+    if instrument_httpx:
+        HTTPXClientInstrumentor().instrument()
+    
+    return trace.get_tracer(service_name)


### PR DESCRIPTION
Fixes #305

CLI exports traces. Chainlit doesn't. This adds trace export to chainlit.

Also moved shared constants to config.py and created setup_tracing() utility to reduce code duplication.