### PR TITLE
Update eval instructions

### DIFF
--- a/scripts/wait_for_mcpd_servers.sh
+++ b/scripts/wait_for_mcpd_servers.sh
@@ -12,7 +12,7 @@ interval=2
 URL="http://localhost:8090/api/v1/health/servers"
 
 while [ $elapsed -lt $timeout ]; do
-    response=$(curl -s --fail --connect-timeout 10 $URL 2>/dev/null)
+    response=$(curl -s --fail --connect-timeout $timeout $URL 2>/dev/null)
     if [ $? -eq 0 ] && [ "$(echo "$response" | jq '.servers | all(.status == "ok")' 2>/dev/null)" = "true" ]; then
         echo "All servers are up!"
         exit 0

--- a/scripts/wait_for_mcpd_servers.sh
+++ b/scripts/wait_for_mcpd_servers.sh
@@ -5,7 +5,7 @@
 # - repeats this every $interval seconds until $timeout is reached
 # - if all servers are ok before $timeout, returns 0, 1 otherwise
 
-timeout=10
+timeout=20
 elapsed=0
 interval=2
 

--- a/src/agent_factory/eval/generate_evaluation_case.py
+++ b/src/agent_factory/eval/generate_evaluation_case.py
@@ -32,7 +32,7 @@ class JSONEvaluationCase(BaseModel):
 def main(
     generated_workflow_dir: str,
     framework: AgentFramework = AgentFramework.TINYAGENT,
-    model: str = "openai/gpt-4.1",
+    model: str = "openai/o3",
 ):
     """Generate JSON structured evaluation case for the generated agentic workflow.
     Save the JSON file as `evaluation_case.json` in the same directory as the generated workflow.

--- a/src/agent_factory/eval/instructions.py
+++ b/src/agent_factory/eval/instructions.py
@@ -4,19 +4,6 @@ The structured JSON output is saved as JSON format.
 
 from jinja2 import Template
 
-WEBPAGE_DESCRIPTIONS = {
-    "https://mozilla-ai.github.io/any-agent/tracing/": (
-        "Useful for debugging and monitoring agent behavior with OpenTelemetry traces."
-        "This page shows how to capture, visualize, "
-        "and analyze agent execution traces for better insights."
-    ),
-    "https://mozilla-ai.github.io/any-agent/evaluation/": (
-        "Consult when implementing evaluation for your agent systems."
-        "This page provides a trace-first approach to evaluate"
-        "agent performance against custom criteria using LLM-as-a-judge techniques."
-    ),
-}
-
 EVALUATION_CATEGORIES = """
 1. **Tool Usage**: Verify correct tool selection and invocation for each sub-task
 2. **Information Retrieval**: Ensure all necessary data is gathered
@@ -123,12 +110,6 @@ Analyze the agent's task, tools, and expected workflow to create thorough evalua
 ## Evaluation Categories to Cover
 {{ evaluation_categories }}
 
-You may access to the following webpages using `visit_webpage` tool:
-
-{% for url, description in webpage_descriptions.items() %}
-- {{ url }}: {{ description }}
-{% endfor %}
-
 ## Example of agent.py script and corresponding JSON evaluation file
 
 {{ agent_script_and_json_example }}
@@ -141,7 +122,6 @@ def get_instructions(generated_workflow_dir: str) -> str:
     template = Template(INSTRUCTIONS_TEMPLATE)
     return template.render(
         generated_workflow_dir=generated_workflow_dir,
-        webpage_descriptions=WEBPAGE_DESCRIPTIONS,
         evaluation_categories=EVALUATION_CATEGORIES,
         agent_script_and_json_example=AGENT_SCRIPT_AND_JSON_EXAMPLE,
     )

--- a/src/agent_factory/eval/instructions.py
+++ b/src/agent_factory/eval/instructions.py
@@ -4,6 +4,8 @@ The structured JSON output is saved as JSON format.
 
 from jinja2 import Template
 
+LLM_JUDGE_MODEL = "openai/gpt-4.1"
+
 EVALUATION_CATEGORIES = """
 1. **Tool Usage**: Verify correct tool selection and invocation for each sub-task
 2. **Information Retrieval**: Ensure all necessary data is gathered
@@ -94,9 +96,6 @@ agent.run(prompt=user_input)
   ]
 }
 ```
-
-Always use openai/gpt-4.1 as the llm_judge.
-
 """  # noqa: E501
 
 INSTRUCTIONS_TEMPLATE = """
@@ -111,8 +110,9 @@ Analyze the agent's task, tools, and expected workflow to create thorough evalua
 {{ evaluation_categories }}
 
 ## Example of agent.py script and corresponding JSON evaluation file
-
 {{ agent_script_and_json_example }}
+
+Always use {{ llm_judge }} as the llm_judge.
 
 """  # noqa: E501
 
@@ -124,4 +124,5 @@ def get_instructions(generated_workflow_dir: str) -> str:
         generated_workflow_dir=generated_workflow_dir,
         evaluation_categories=EVALUATION_CATEGORIES,
         agent_script_and_json_example=AGENT_SCRIPT_AND_JSON_EXAMPLE,
+        llm_judge=LLM_JUDGE_MODEL,
     )


### PR DESCRIPTION
## 📝 What's changing

This PR includes a series of small refactorings and cleanups to the evaluation instructions.

The changes are:
 - The example code is updated to use mcpd instead of MCPStdio.
 - The LLM model used as a Judge is now configurable.
 - The hardcoded list of webpages is removed from the evaluation generation prompt.

Closes #319

---

## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [ ] Added some tests for any new functionality
- [x] Tested the changes in a working environment to ensure they work as expected
- [x] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [insert-link-here]
  >Note: The can be done from [Actions tab in GitHub UI](https://github.com/mozilla-ai/agent-factory/actions/workflows/tests.yaml) -> Select the pinned `Tests` workflow from the left sidebar -> Select `your-branch-name` -> `Run workflow`
