### PR TITLE
Pin any-llm-sdk version to avoid incompatibilities from future releases

### DIFF
--- a/docs/sample_workflows/hello_world/requirements.txt
+++ b/docs/sample_workflows/hello_world/requirements.txt
@@ -1,4 +1,5 @@
 any-agent[all]==1.9.0
+any-llm-sdk==0.20.2
 beautifulsoup4
 fire
 litellm<1.75.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "any-agent[a2a]==1.9.0",
+    "any-llm-sdk==0.20.2",
     "autoflake==2.3.1",
     "boto3",
     "python-dotenv>=1.1.1",

--- a/scripts/wait_for_mcpd_servers.sh
+++ b/scripts/wait_for_mcpd_servers.sh
@@ -5,7 +5,7 @@
 # - repeats this every $interval seconds until $timeout is reached
 # - if all servers are ok before $timeout, returns 0, 1 otherwise
 
-timeout=10
+timeout=20
 elapsed=0
 interval=2
 

--- a/src/agent_factory/instructions.py
+++ b/src/agent_factory/instructions.py
@@ -407,8 +407,8 @@ using Mozilla's any-agent library. The implementation should:
 - Define Pydantic v2 models to structure the agent's final output
 - Implement the `output_type` argument correctly to obtain this structured response
 
-#### Agent Trace (agent_trace): Conditional on the whether the agent code requested is run via CLI or A2AServing
-Important: Saving agent_trace is ONLY required when running the agent via CLI with `agent.run()`. You MUST NEVER save the agent trace when running the agent via A2AServing.
+#### Agent Trace (agent_trace):
+Important: Saving agent_trace is required when running the agent via CLI with `agent.run()`.
 If the code corresponds to running the agent via CLI, use the following instructions to save the agent trace:
 - Include the agent trace being saved into a JSON file named `agent_eval_trace.json` immediately after agent.run()
 - Saving of the agent trace in the code should be done to the `script_dir / "agent_eval_trace.json"` directory as shown in the example code

--- a/src/agent_factory/utils/artifact_validation.py
+++ b/src/agent_factory/utils/artifact_validation.py
@@ -8,6 +8,7 @@ from agent_factory.schemas import CodeSnippet, SyntaxErrorMessage
 from agent_factory.utils.logging import logger
 
 ANY_AGENT_VERSION = importlib.metadata.version("any_agent")
+ANY_LLM_VERSION = importlib.metadata.version("any_llm_sdk")
 
 
 def clean_python_code_with_autoflake(code: str) -> str:
@@ -146,9 +147,12 @@ def validate_dependencies(tools: str, dependencies: list[str]) -> str:
         logger.info("Agent uses uvx but deps were missing uv: adding manually.")
         final_dependencies.append("uv")
 
-    if "any-agent" in final_dependencies:
-        logger.info(f"Pinning any-agent to version {ANY_AGENT_VERSION}")
-        final_dependencies = list(filter(lambda dependency: not dependency.startswith("any-agent"), final_dependencies))
-        final_dependencies.append(f"any-agent[all]=={ANY_AGENT_VERSION}")
+    logger.info(f"Pinning any-agent to version {ANY_AGENT_VERSION}")
+    final_dependencies = list(filter(lambda dependency: not dependency.startswith("any-agent"), final_dependencies))
+    final_dependencies.append(f"any-agent[all]=={ANY_AGENT_VERSION}")
+
+    logger.info(f"Pinning any-llm-sdk to version {ANY_LLM_VERSION}")
+    final_dependencies = list(filter(lambda dependency: not dependency.startswith("any-llm-sdk"), final_dependencies))
+    final_dependencies.append(f"any-llm-sdk=={ANY_LLM_VERSION}")
 
     return "\n".join(final_dependencies)

--- a/tests/artifacts/scoring-blueprints-submission/requirements.txt
+++ b/tests/artifacts/scoring-blueprints-submission/requirements.txt
@@ -1,4 +1,5 @@
 any-agent[all]==1.9.0
+any-llm-sdk==0.20.2
 fire
 litellm
 markdownify

--- a/tests/artifacts/summarize-url-content/requirements.txt
+++ b/tests/artifacts/summarize-url-content/requirements.txt
@@ -1,4 +1,5 @@
 any-agent[all]==1.9.0
+any-llm-sdk==0.20.2
 fire
 litellm
 markdownify

--- a/tests/artifacts/url-to-podcast/requirements.txt
+++ b/tests/artifacts/url-to-podcast/requirements.txt
@@ -1,4 +1,5 @@
 any-agent[all]==1.9.0
+any-llm-sdk==0.20.2
 beautifulsoup4
 fire
 litellm

--- a/tests/generation/requirements_validators.py
+++ b/tests/generation/requirements_validators.py
@@ -24,6 +24,26 @@ def assert_requirements_includes_any_agent_version(requirements_path: Path):
         )
 
 
+def assert_requirements_includes_any_llm_version(requirements_path: Path):
+    """Verify that the requirements.txt includes any-llm-sdk=={version}."""
+    content = requirements_path.read_text(encoding="utf-8").strip()
+    lines = content.split("\n")
+
+    if not lines:
+        raise AssertionError(f"requirements.txt is empty\n\nFull requirements.txt content:\n{content}")
+
+    # Get the expected version from the installed any-llm-sdk package
+    expected_version = version("any-llm-sdk")
+    expected_line = f"any-llm-sdk=={expected_version}"
+
+    # Find the expected line in the requirements file
+    if expected_line not in lines:
+        raise AssertionError(
+            f"Missing required dependency: '{expected_line}' not found in requirements.txt\n\n"
+            f"Full requirements.txt content:\n{content}"
+        )
+
+
 def assert_mcp_uv_consistency(agent_file: Path, requirements_path: Path):
     """Verify MCP tool usage consistency with uv dependency."""
     agent_content = agent_file.read_text(encoding="utf-8")

--- a/tests/generation/test_single_turn_generation.py
+++ b/tests/generation/test_single_turn_generation.py
@@ -7,6 +7,7 @@ from any_agent.tracing.agent_trace import AgentTrace
 from requirements_validators import (
     assert_mcp_uv_consistency,
     assert_requirements_includes_any_agent_version,
+    assert_requirements_includes_any_llm_version,
     assert_requirements_installable,
 )
 from utils.non_deterministic_runs import run_until_success_threshold_async
@@ -196,6 +197,7 @@ async def test_single_turn_generation(
 
     # Assertions based on requirements.txt
     assert_requirements_includes_any_agent_version(full_path / "requirements.txt")
+    assert_requirements_includes_any_llm_version(full_path / "requirements.txt")
     assert_mcp_uv_consistency(full_path / "agent.py", full_path / "requirements.txt")
     assert_requirements_installable(full_path / "requirements.txt")
 

--- a/tests/unit/test_artifact_validation.py
+++ b/tests/unit/test_artifact_validation.py
@@ -19,7 +19,14 @@ class TestValidateDependencies:
     def test_adds_uv_when_uvx_in_tools(self, sample_generator_agent_response_json):
         """Test that uv is added when uvx is found in tools."""
         tools = sample_generator_agent_response_json["tools"] + "\n# uvx install some-mcp-server"
-        dependencies = ["any-agent[all]==0.25.0", "python-dotenv", "beautifulsoup4", "requests", "fire"]
+        dependencies = [
+            "any-agent[all]==1.9.0",
+            "any-llm-sdk==0.20.2",
+            "python-dotenv",
+            "beautifulsoup4",
+            "requests",
+            "fire",
+        ]
 
         result = validate_dependencies(tools, dependencies)
 

--- a/tests/unit/test_io_utils.py
+++ b/tests/unit/test_io_utils.py
@@ -18,9 +18,7 @@ def test_prepare_agent_artifacts(sample_generator_agent_response_json):
     """Test that prepare_agent_artifacts correctly prepares the artifacts."""
     artifacts = prepare_agent_artifacts(sample_generator_agent_response_json)
 
-    expected_dependencies = (
-        "python-dotenv\npydantic\nfire\nmcpd\nany-agent[all]==1.9.0\nlitellm\nbeautifulsoup4\nrequests\ntavily-python"
-    )
+    expected_dependencies = "python-dotenv\npydantic\nfire\nmcpd\nany-agent[all]==1.9.0\nany-llm-sdk==0.20.2\nlitellm\nbeautifulsoup4\nrequests\ntavily-python"
 
     assert "agent.py" in artifacts
     assert "README.md" in artifacts

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "any-agent", extra = ["a2a"] },
+    { name = "any-llm-sdk" },
     { name = "autoflake" },
     { name = "boto3" },
     { name = "fire" },
@@ -87,6 +88,7 @@ requires-dist = [
     { name = "any-agent", extras = ["a2a"], specifier = "==1.9.0" },
     { name = "any-agent", extras = ["langchain"], marker = "extra == 'langchain'" },
     { name = "any-agent", extras = ["openai"], marker = "extra == 'openai'" },
+    { name = "any-llm-sdk", specifier = "==0.20.2" },
     { name = "autoflake", specifier = "==2.3.1" },
     { name = "boto3" },
     { name = "fire", specifier = "~=0.7.0" },


### PR DESCRIPTION
## 📝 What's changing

While we are not actively maintaining this project, it would be nice to have it running without errors for users (with the existing features and capabilities).
One issue that users might face: `any-agent==1.9.0` relies on `any-llm-sdk>=0.20.2,<1` which means breaking changes introduced in version `0.21.0` throws errors when attempting to run the target agent.

This PR pins any-llm-sdk to a tested working version (0.20.2) both for the manufacturing and target agent. 

---


## ✅ Pre-merge checklist

Please ensure the following items are checked **before merging** the PR (if not, please add a small explanation why).

- [x] Added some tests for any new functionality
- [x] Tested the changes in a working environment to ensure they work as expected
- [x] [Manually triggered](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) workflows from this branch and ensured that test that involve agent generation using LLM API keys run successfully. Link to successful workflow run: [[insert-link-here](https://github.com/mozilla-ai/agent-factory/actions/runs/18656805485)]

---

## 📸 Screenshots (if applicable)

Please add any relevant screenshots to show the changes (e.g. agent performance in comparison to `main` branch).
